### PR TITLE
Config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist
 rt1.egg-info
 .ipynb_checkpoints
 .spyproject
+_additional_and_old_scripts
+rt1/.pylint.d
+.gitmodules

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/TUW-GEO/rt1.svg?branch=master)](https://travis-ci.org/TUW-GEO/rt1) [![Documentation Status](https://readthedocs.org/projects/rt1/badge/?version=latest)](http://rt1.readthedocs.io/) [![Coverage Status](https://coveralls.io/repos/github/TUW-GEO/rt1/badge.svg?branch=coveralls_test)](https://coveralls.io/github/TUW-GEO/rt1?branch=coveralls_test)
+[![Build Status](https://travis-ci.org/TUW-GEO/rt1.svg?branch=dev)](https://travis-ci.org/TUW-GEO/rt1) [![Documentation Status](https://readthedocs.org/projects/rt1/badge/?version=latest)](http://rt1.readthedocs.io/) [![Coverage Status](https://coveralls.io/repos/github/TUW-GEO/rt1/badge.svg?branch=dev)](https://coveralls.io/github/TUW-GEO/rt1?branch=dev)
 
 # RT1 - bistatic scattering model for first order scattering of random media
 

--- a/rt1/rtfits.py
+++ b/rt1/rtfits.py
@@ -2103,7 +2103,7 @@ class RT1_configparser(object):
                                     float_keys = ['ftol', 'gtol', 'xtol'])
 
         self.fitprop_parse_props = dict(section = 'general_RT1_properties',
-                                        bool_keys = ['int_q'])
+                                        bool_keys = ['int_Q'])
 
         self.fitargs_parse_props = dict(section = 'fits_kwargs',
                                         bool_keys = ['sig0', 'dB'])

--- a/rt1/rtfits.py
+++ b/rt1/rtfits.py
@@ -22,7 +22,6 @@ from . import volume as rt1_v
 
 import copy
 import multiprocessing as mp
-from itertools import chain, repeat
 from functools import partial
 
 try:

--- a/rt1/rtfits.py
+++ b/rt1/rtfits.py
@@ -2291,13 +2291,14 @@ class RT1_configparser(object):
             parsed_val = []
             parsed_val += [bool(val[0])]
             parsed_val += [float(val[1])]
-            if val[2] == 'None':
-                parsed_val += [None]
-            else:
-                parsed_val += [val[2]]
+            if len(val) > 2:
+                if val[2] == 'None':
+                    parsed_val += [None]
+                else:
+                    parsed_val += [val[2]]
 
-            parsed_val += [([float(val[3])],
-                            [float(val[4])])]
+                parsed_val += [([float(val[3])],
+                                [float(val[4])])]
 
             parsed_dict[key] = parsed_val
 

--- a/rt1/rtfits.py
+++ b/rt1/rtfits.py
@@ -1033,20 +1033,14 @@ class Fits(Scatter):
         vsymb = set(map(str, R.V._func.free_symbols)) - angset
         srfsymb = set(map(str, R.SRF._func.free_symbols)) - angset
 
-        param_fn = res_dict.copy()
-        param_fn.pop('omega', None)
-        param_fn.pop('tau', None)
-        param_fn.pop('NormBRDF', None)
-        param_fn.pop('bsf', None)
+        # exclude all keys that are not needed to calculate the fn-coefficients
         # vsymb and srfsymb must be subtracted in case the same symbol is used
         # for omega, tau or NormBRDF definition and in the function definiton
-        for i in set(toNlist - vsymb - srfsymb):
-            param_fn.pop(str(i), None)
+        excludekeys = ['omega', 'tau', 'NormBRDF', 'bsf',
+                       *[str(i) for i in set(toNlist - vsymb - srfsymb)]]
 
-        # ensure that the keys of the dict are strings and not sympy-symbols
-        strparam_fn = dict([[str(key),
-                             param_fn[key]]
-                            for i, key in enumerate(param_fn.keys())])
+        strparam_fn = {str(key) : val for key, val in res_dict.items()
+                       if key not in excludekeys}
 
         # set the param-dict to the newly generated dict
         R.param_dict = strparam_fn

--- a/rt1/rtfits.py
+++ b/rt1/rtfits.py
@@ -56,7 +56,6 @@ class Fits(Scatter):
              If a column 'data_weights' is provided, the residuals in the
              fit-procedure will be weighted accordingly.
              (e.g. residuals = weights * calculated_residuals )
-
     defdict: dict (default = None)
              a dictionary of the following structure:
              (the dict will be copied internally using copy.deepcopy(dict))
@@ -103,7 +102,6 @@ class Fits(Scatter):
                          Notice: The index must coinicide
                          with the index of the dataset, and the column-name
                          must be the corresponding variabile-name
-
     set_V_SRF: callable (default = None)
                function with the following structure:
 
@@ -115,11 +113,9 @@ class Fits(Scatter):
                >>>     SRF = Surface-function(surface-keys)
                >>>
                >>>     return V, SRF
-
     fitset: dict (default = dict())
             a dictionary with keyword-arguments passed to monofit() and further
             to scipy.optimize.least_squares
-
     setindex: str (default = 'mean')
               indicator how the datetime-indices of the fit-results
               should be processed. possible values are:
@@ -129,7 +125,6 @@ class Fits(Scatter):
                   - 'original': return the full list of datetime-objects
     int_Q: bool (default = True)
            indicator if the interaction-term should be evaluated or not.
-
     lambda_backend: str, optional
                     select method for generating the _fnevals functions
                     if they are not provided explicitly and int_Q is True
@@ -213,7 +208,6 @@ class Fits(Scatter):
 
         # add plotfunctions
         self.plot = rt1_plots(self)
-
 
 
     def __update__(self):
@@ -454,6 +448,7 @@ class Fits(Scatter):
             elif isinstance(self.dataset_used, list):
                 self.index = range(len(self.dataset_used))
 
+
     def _preparedata(self, dataset):
         '''
         prepare data such that it is applicable to least_squres fitting
@@ -552,6 +547,7 @@ class Fits(Scatter):
 
         return [inc, np.concatenate(data), np.concatenate(weights),
                 N, mask, new_fixed_dict]
+
 
     def _assignvals(self, res_dict):
         if self.interp_vals is not None and isinstance(self.interp_vals, list):
@@ -1041,12 +1037,10 @@ class Fits(Scatter):
                     if prop == 'mask':
                         return mask
 
-
     data = property(partial(__get_data, prop='sig'))
     inc = property(partial(__get_data, prop='inc'))
     weights = property(partial(__get_data, prop='weights'))
     mask = property(partial(__get_data, prop='mask'))
-
 
 
     def _calc_slope_curv(self, R=None, res_dict=None, fixed_dict=None,
@@ -1195,6 +1189,7 @@ class Fits(Scatter):
         return {'slope' : model_slope,
                 'curv' : model_curv}
 
+
     def _init_V_SRF(self, V_props, SRF_props, setdict=dict()):
         '''
         initialize a volume and a surface scattering function based on
@@ -1246,7 +1241,6 @@ class Fits(Scatter):
                         replacements[val_i] = setdict[str(val_i)]
                 useval = useval.xreplace(replacements)
 
-
             V_dict[key] = useval
 
         # same for SRF
@@ -1272,6 +1266,7 @@ class Fits(Scatter):
         SRF = getattr(rt1_s, SRF_props['SRF_name'])(**SRF_dict)
 
         return V, SRF
+
 
     def monofit(self, V, SRF, dataset, param_dict, bsf=0.,
                 bounds_dict={}, fixed_dict={}, param_dyn_dict={},
@@ -1432,7 +1427,7 @@ class Fits(Scatter):
                  be executed. This re-initializes the Fits object based on the
                  input in the state as if the fit has already been performed.
 
-        kwargs:
+        lsq_kwargs: dict (default = {})
                 keyword arguments passed to scipy's least_squares function
 
         Returns:
@@ -1465,8 +1460,6 @@ class Fits(Scatter):
                 self.intermediate_results = {'parameters':[],
                                              'residuals':[],
                                              'jacobian':[]}
-
-
 
         # generate a list of the names of the parameters that will be fitted.
         # (this is necessary to ensure correct broadcasting of values since
@@ -1508,8 +1501,11 @@ class Fits(Scatter):
         self._setindex(self.setindex)
         # get a dict of the mean datetime-values for each parameter
         try:
-            self.meandatetimes = {param: pd.to_datetime([meandatetime(val) for key, val in self.index.groupby(np.repeat(*param_repeat)).items()])
-                                  for param, param_repeat in repeatdict.items()}
+            self.meandatetimes = {
+                param: pd.to_datetime(
+                    [meandatetime(val) for key, val in self.index.groupby(
+                        np.repeat(*param_repeat)).items()])
+                for param, param_repeat in repeatdict.items()}
         except:
             pass
         # preparation of data for fitting
@@ -1560,40 +1556,9 @@ class Fits(Scatter):
             str((vsymb | srfsymb) - paramset) +
             ' must be provided in param_dict')
 
-
-# TODO fix asserts
-#        if omega is not None and not np.isscalar(omega):
-#            assert len(omega) == Nmeasurements, ('len. of omega-array must' +
-#                      'be equal to the length of the dataset')
-#        if omega is None:
-#            assert len(V.omega) == Nmeasurements, ('length of' +
-#                      ' omega-array provided in the definition of V must' +
-#                      ' be equal to the length of the dataset')
-#
-#        if tau is not None and not np.isscalar(tau):
-#            assert len(tau) == Nmeasurements, ('length of tau-array' +
-#                      ' must be equal to the length of the dataset')
-#
-#        if tau is None:
-#            assert len(V.tau) == Nmeasurements, ('length of tau-array' +
-#                      ' provided in the definition of V must be equal to' +
-#                      ' the length of the dataset')
-#
-#        if NormBRDF is not None and not np.isscalar(NormBRDF):
-#            assert len(NormBRDF) == Nmeasurements, ('length of' +
-#                      ' NormBRDF-array must be equal to the' +
-#                      ' length of the dataset')
-#        if NormBRDF is None:
-#            assert len(SRF.NormBRDF) == Nmeasurements, ('length of' +
-#                      ' NormBRDF-array provided in the definition of SRF' +
-#                      ' must be equal to the length of the dataset')
-#
         # generate a dict containing only the parameters needed to evaluate
         # the fn-coefficients
-        # for python > 3.4
-        # param_R = dict(**param_dict, **fixed_dict)
-        param_R = dict((k, v) for k, v in list(param_dict.items())
-                       + list(fixed_dict.items()))
+        param_R = dict(**param_dict, **fixed_dict)
         param_R.pop('omega', None)
         param_R.pop('tau', None)
         param_R.pop('NormBRDF', None)
@@ -1647,7 +1612,6 @@ class Fits(Scatter):
                 errdict = {'abserr' : errs,
                            'relerr' : errs/data}
                 self.intermediate_results['residuals'] += [errdict]
-
 
             return errs
 
@@ -1718,11 +1682,8 @@ class Fits(Scatter):
             self.res_dict = res_dict
             self.start_dict = start_dict
 
-
         # ------------------------------------------------------------------
         # ------------ prepare output-data for later convenience -----------
-
-
         self.R = R
         self.fixed_dict = fixed_dict
         self.res_dict = getattr(self, 'res_dict', dict())
@@ -1932,7 +1893,6 @@ class Fits(Scatter):
                      re_init=re_init,
                      lsq_kwargs=self.fitset,
                      **kwargs)
-
 
 
     def _evalfunc(self, reader=None, reader_arg=None, fitset=None,
@@ -2228,12 +2188,12 @@ class Fits(Scatter):
         self.performfit(re_init=True)
 
 
-
 class RT1_configparser(object):
     def __init__(self, configpath):
         # setup config (allow empty values -> will result in None)
         self.config = ConfigParser(allow_no_value=True)
-        # avoid converting uppercase characters (see https://stackoverflow.com/a/19359720/9703451)
+        # avoid converting uppercase characters
+        # (see https://stackoverflow.com/a/19359720/9703451)
         self.config.optionxform = str
         # read config file
         self.cfg = self.config.read(configpath)

--- a/rt1/rtfits.py
+++ b/rt1/rtfits.py
@@ -1686,7 +1686,7 @@ class Fits(Scatter):
                     if manual_dyn_df is None: manual_dyn_df = pd.DataFrame()
                     manual_dyn_df = pd.concat([manual_dyn_df,
                                                defdict[key][4]], axis=1)
-                if defdict[key][2] == 'index':
+                elif defdict[key][2] == 'index':
                     indexdyn = pd.DataFrame({key:1}, self.dataset.index
                                             ).groupby(axis=0, level=0
                                                       ).ngroup().to_frame()

--- a/rt1/rtfits.py
+++ b/rt1/rtfits.py
@@ -604,19 +604,14 @@ class Fits(Scatter):
         vsymb = set(map(str, R.V._func.free_symbols)) - angset
         srfsymb = set(map(str, R.SRF._func.free_symbols)) - angset
 
-        param_fn = res_dict.copy()
-        param_fn.pop('omega', None)
-        param_fn.pop('tau', None)
-        param_fn.pop('NormBRDF', None)
-        param_fn.pop('bsf', None)
+        # exclude all keys that are not needed to calculate the fn-coefficients
         # vsymb and srfsymb must be subtracted in case the same symbol is used
         # for omega, tau or NormBRDF definition and in the function definiton
-        for i in set(toNlist - vsymb - srfsymb):
-            param_fn.pop(str(i), None)
+        excludekeys = ['omega', 'tau', 'NormBRDF', 'bsf',
+                       *[str(i) for i in set(toNlist - vsymb - srfsymb)]]
 
-        # ensure that the keys of the dict are strings and not sympy-symbols
-        strparam_fn = dict([[str(key), param_fn[key]]
-                            for i, key in enumerate(param_fn.keys())])
+        strparam_fn = {str(key) : val for key, val in res_dict.items()
+                       if key not in excludekeys}
 
         # set the param-dict to the newly generated dict
         R.param_dict = strparam_fn
@@ -729,18 +724,14 @@ class Fits(Scatter):
         vsymb = set(map(str, R.V._func.free_symbols)) - angset
         srfsymb = set(map(str, R.SRF._func.free_symbols)) - angset
 
-        param_fn = res_dict.copy()
-        param_fn.pop('omega', None)
-        param_fn.pop('tau', None)
-        param_fn.pop('NormBRDF', None)
-        param_fn.pop('bsf', None)
+        # exclude all keys that are not needed to calculate the fn-coefficients
+        # vsymb and srfsymb must be subtracted in case the same symbol is used
+        # for omega, tau or NormBRDF definition and in the function definiton
+        excludekeys = ['omega', 'tau', 'NormBRDF', 'bsf',
+                       *[str(i) for i in set(toNlist - vsymb - srfsymb)]]
 
-        for i in set(toNlist - vsymb - srfsymb):
-            param_fn.pop(str(i), None)
-
-        # ensure that the keys of the dict are strings
-        strparam_fn = dict([[str(key), param_fn[key]]
-                            for i, key in enumerate(param_fn.keys())])
+        strparam_fn = {str(key) : val for key, val in res_dict.items()
+                       if key not in excludekeys}
 
         # set the param-dict to the newly generated dict
         R.param_dict = strparam_fn

--- a/rt1/rtfits.py
+++ b/rt1/rtfits.py
@@ -922,6 +922,21 @@ class Fits(Scatter):
 
         return jac_lsq
 
+    def _get_res_df(self):
+        '''
+        return a pandas DataFrame with the obtained parameters
+        '''
+        newdict = dict()
+        for key, val in self.res_dict.items():
+            if isinstance(val[1], (int, float)):
+                newdict[key] = chain.from_iterable(repeat(val[0], val[1]))
+            else:
+                newdict[key] = chain.from_iterable(
+                    [repeat(i, int(j)) for i,j in np.array(val).T])
+        return pd.DataFrame(newdict, self.index)
+
+    res_df = property(_get_res_df)
+
 
     def _calc_slope_curv(self, R=None, res_dict=None, fixed_dict=None,
                          return_components=False):

--- a/rt1/rtfits.py
+++ b/rt1/rtfits.py
@@ -237,22 +237,20 @@ class Fits(Scatter):
             print('... re-initializing plot-functions')
             self.plot = rt1_plots(self)
 
-        if not hasattr(self, 'lsq_kwargs'):
-            self.lsq_kwargs = dict()
 
         if hasattr(self, 'fitset'):
-            if not hasattr(self, 'int_Q'):
-                self.int_Q = self.fitset.pop('int_Q', True)
-
-            if not hasattr(self, 'lambda_backend'):
-                self.lambda_backend = self.fitset.pop('lambda_backend',
-                                                      _init_lambda_backend)
-
-            if not hasattr(self, '_fnevals_input'):
-                self._fnevals_input = self.fitset.pop('_fnevals_input',
-                                                      None)
             self.lsq_kwargs = self.fitset
             del self.fitset
+        if not hasattr(self, 'lsq_kwargs'):
+            self.lsq_kwargs = dict()
+        if not hasattr(self, 'int_Q'):
+            self.int_Q = self.lsq_kwargs.pop('int_Q', True)
+        if not hasattr(self, 'lambda_backend'):
+            self.lambda_backend = self.lsq_kwargs.pop('lambda_backend',
+                                                      _init_lambda_backend)
+        if not hasattr(self, '_fnevals_input'):
+            self._fnevals_input = self.lsq_kwargs.pop('_fnevals_input',
+                                                      None)
 
         if not hasattr(self, 'interp_vals'):
             self.interp_vals = None

--- a/rt1/rtfits.py
+++ b/rt1/rtfits.py
@@ -214,6 +214,11 @@ class Fits(Scatter):
 
             delattr(self, '_rt1_dump_mini')
 
+            # remove pre-evaluated fn-evals functions
+            if (getattr(self, 'fitset', None) is not None
+                and '_fnevals_input' in self.fitset):
+                self.fitset['_fnevals_input'] = None
+
             return {key: val for key, val in self.__dict__.items()
                     if key not in removekeys}
 

--- a/rt1/rtfits.py
+++ b/rt1/rtfits.py
@@ -241,6 +241,9 @@ class Fits(Scatter):
             print('... re-initializing plot-functions')
             self.plot = rt1_plots(self)
 
+        if not hasattr(self, 'fitset'):
+            self.fitset = dict()
+
         if not hasattr(self, 'int_Q'):
             self.int_Q = self.fitset.pop('int_Q', True)
 

--- a/rt1/rtplots.py
+++ b/rt1/rtplots.py
@@ -2393,10 +2393,7 @@ class plot:
         if fit is not None:
             res_dict = getattr(fit, 'res_dict', None)
 
-            try:
-                _fnevals_input = fit.R._fnevals
-            except Exception:
-                pass
+            _fnevals_input = getattr(fit, '_fnevals_input', None)
 
             if defdict is None:
                 defdict = fit.defdict
@@ -2491,9 +2488,12 @@ class plot:
 
         # overplot data used in fit
         try:
-            ax.plot(fit.R.t_0.T,
-                    dBsig0convert(fit.data.T, fit.R.t_0.T,
-                                  dB, sig0, fit.dB, fit.sig0), '.', zorder=0)
+            ax.plot(fit.dataset.inc,
+                    dBsig0convert(fit.dataset.sig, fit.dataset.inc,
+                                  dB, sig0, fit.dB, fit.sig0),
+                    zorder=0, marker='.', alpha=0.5, lw=0,
+                    markerfacecolor='none', markeredgecolor='k')
+
         except:
             pass
 
@@ -2566,9 +2566,9 @@ class plot:
 
             params[key] = value
             modelresult = _getbackscatter(fit=fit, set_V_SRF=set_V_SRF,
-                                         int_Q=int_Q, inc=inc,
-                                         params=params, dB=dB, sig0=sig0,
-                                         _fnevals_input = _fnevals_input)
+                                          int_Q=int_Q, inc=inc,
+                                          params=params, dB=dB, sig0=sig0,
+                                          _fnevals_input = _fnevals_input)
             # update the data
             ltot.set_ydata(modelresult['tot'].T)
             lsurf.set_ydata(modelresult['surf'].T)

--- a/rt1/rtplots.py
+++ b/rt1/rtplots.py
@@ -858,16 +858,11 @@ class plot:
         if fit is None:
             fit = self.fit
 
-        # reset incidence-angles in case they have been altered beforehand
-        fit.R.t_0 = fit.inc
-        fit.R.p_0 = np.zeros_like(fit.inc)
-
         fig = plt.figure()
         ax = fig.add_subplot(111)
 
         if newcalc is True:
-
-            estimates = fit._calc_model(fit.R, fit.res_dict, fit.fixed_dict)
+            estimates = fit._calc_model()
 
             # apply mask
             estimates = estimates[~fit.mask]

--- a/tests/test_config.ini
+++ b/tests/test_config.ini
@@ -1,0 +1,77 @@
+###############################################################################
+# GENERAL SPECIFICATIONS
+###############################################################################
+[fits_kwargs]
+# set dataset-properties (e.g. if the input-dataset is in dB or not)
+sig0     = True
+dB       = False
+# define how the index of the results should be set (first, last or mean)
+setindex = first
+# indicator if interaction term should be evaluated
+int_Q          = False
+# backend to use for symbolic evaluation of the interaction term functions
+lambda_backend = symengine
+interp_vals     = [tau, omega]
+_fnevals_input
+
+[least_squares_kwargs]
+# keyword-arguments passed to scipy.optimize.least_squares
+# level of print-output
+verbose   = 2
+# termination tolerances
+ftol      = 1.e-4
+gtol      = 1.e-4
+xtol      = 1.e-4
+# maximum number of function evaluations
+max_nfev  = 20
+# used minimization algorithm (trf or dogbox)
+method    = trf
+# method for solving the trust-regions (lsmr or exact)
+tr_solver = lsmr
+# characteristic scale of each variable (jac = use inverse norm of jacobian )
+x_scale   = jac
+
+
+###############################################################################
+# RT1 MODEL SPECIFICATIONS
+###############################################################################
+[defdict]
+# provide specifications in the following order:
+# parameter = [fitQ, startval, frequency, min, max]
+# fitQ     ... indicator if the parameter should be fitted or not
+# startval ... the start-value to use if the parameter is fitted or the
+#              constant value to use in case it is not fitted
+# freqency ... the variability of the parameters specified as pandas dateoffset
+#              https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#dateoffset-objects
+# min/max  ... the boundary-values used in case the parameter is fitted
+
+omega = [True, 0.05, 2M,    0.01, 0.5]
+t_v   = [True, 0.25, None,  0.01, 0.5]
+t_s   = [True, 0.25, None,  0.01, 0.5]
+N     = [True, 0.1,  index, 0.01, 0.2]
+tau   = [True, 0.5,  3M,    0.01, 1.5]
+bsf   = [True, 0.05, A,     0.01, 1.]
+
+
+[RT1_V]
+# the name of the volume-scattering function used (provided in rt1.volume)
+V_name = HenyeyGreenstein
+# parameter assignments
+# ints and floats will be used as constants, strings will be converted
+# to sympy expressions whose free-variables must be set in defdict.
+tau    = tau
+omega  = omega
+t      = t_v
+ncoefs = 10
+
+
+[RT1_SRF]
+# similar as RT1_V but this time the functions of rt1.surface will be used
+SRF_name = HG_nadirnorm
+NormBRDF = N
+t        = t_s
+ncoefs   = 10
+
+
+
+

--- a/tests/test_config.ini
+++ b/tests/test_config.ini
@@ -50,6 +50,7 @@ t_v   = [True, 0.25, None,  0.01, 0.5]
 t_s   = [True, 0.25, None,  0.01, 0.5]
 N     = [True, 0.1,  index, 0.01, 0.2]
 tau   = [True, 0.5,  3M,    0.01, 1.5]
+tau_multip = [False, 0.5]
 bsf   = [True, 0.05, A,     0.01, 1.]
 
 
@@ -59,7 +60,7 @@ V_name = HenyeyGreenstein
 # parameter assignments
 # ints and floats will be used as constants, strings will be converted
 # to sympy expressions whose free-variables must be set in defdict.
-tau    = tau
+tau    = tau * tau_multip
 omega  = omega
 t      = t_v
 ncoefs = 10

--- a/tests/test_configparser.py
+++ b/tests/test_configparser.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+"""
+test configparser
+
+a quick check if a standard config-file is read correctly
+"""
+
+import unittest
+import os
+from rt1.rtfits import RT1_configparser
+
+
+class TestCONFIGPARSER(unittest.TestCase):
+    def setUp(self):
+        self.configpath = os.path.join(os.path.dirname(__file__),
+                                       'test_config.ini')
+
+
+    def test_load_cfg(self):
+        cfg = RT1_configparser(self.configpath)
+
+        lsq_kwargs = {'verbose': 2,
+                      'ftol': 0.0001,
+                      'gtol': 0.0001,
+                      'xtol': 0.0001,
+                      'max_nfev': 20,
+                      'method': 'trf',
+                      'tr_solver': 'lsmr',
+                      'x_scale': 'jac'}
+
+        defdict = {'omega': [True, 0.05, '2M', ([0.01], [0.5])],
+                    't_v': [True, 0.25, None, ([0.01], [0.5])],
+                    't_s': [True, 0.25, None, ([0.01], [0.5])],
+                    'N': [True, 0.1, 'index', ([0.01], [0.2])],
+                    'tau': [True, 0.5, '3M', ([0.01], [1.5])],
+                    'bsf': [True, 0.05, 'A', ([0.01], [1.0])]}
+
+        set_V_SRF = {'V_props': {'V_name': 'HenyeyGreenstein',
+                                 'tau': 'tau',
+                                 'omega': 'omega',
+                                 't': 't_v',
+                                 'ncoefs': 10},
+                     'SRF_props': {'SRF_name': 'HG_nadirnorm',
+                                   'NormBRDF': 'N',
+                                   't': 't_s',
+                                   'ncoefs': 10}}
+
+        fits_kwargs = {'sig0': True,
+                       'dB': False,
+                       'setindex': 'first',
+                       'int_Q': False,
+                       'lambda_backend': 'symengine',
+                       'interp_vals': ['tau', 'omega'],
+                       '_fnevals_input': None}
+
+
+        configdicts = cfg.get_config()
+
+        for key, val in lsq_kwargs.items():
+            assert key in configdicts['lsq_kwargs'], f'error in lsq_kwargs {key}'
+            assert val == configdicts['lsq_kwargs'][key], f'error in lsq_kwargs {key}'
+
+        for key, val in defdict.items():
+            assert key in configdicts['defdict'], f'error in defdict {key}'
+            for i, val_i in enumerate(val[:3]):
+                assert val_i == configdicts['defdict'][key][i], f'error in defdict {key}'
+            assert val[-1][0][0] == configdicts['defdict'][key][-1][0][0], f'error in defdict {key}'
+            assert val[-1][1][0] == configdicts['defdict'][key][-1][1][0], f'error in defdict {key}'
+
+        for key, val in set_V_SRF.items():
+            assert key in configdicts['set_V_SRF'], f'error in set_V_SRF {key}'
+
+            for key_i, val_i in val.items():
+                assert key_i in configdicts['set_V_SRF'][key], f'error in set_V_SRF["{key}"]["{key_i}"]'
+
+                assert val_i == configdicts['set_V_SRF'][key][key_i], f'error in set_V_SRF["{key}"]["{key_i}"]'
+
+        for key, val in fits_kwargs.items():
+            assert key in configdicts['fits_kwargs'], f'error in fits_kwargs {key}'
+            assert val == configdicts['fits_kwargs'][key], f'error in fits_kwargs {key}'
+
+        fit = cfg.get_fitobject()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rtfit_dumps.py
+++ b/tests/test_rtfit_dumps.py
@@ -33,7 +33,7 @@ class TestDUMPS(unittest.TestCase):
 
             print(f'testing plotfunctions for {msg} fit')
             fit = self.load_data(path)
-            fitset = {
+            lsq_kwargs = {
                 'ftol': 1e-3,
                 'gtol': 1e-3,
                 'xtol': 1e-3,
@@ -41,7 +41,7 @@ class TestDUMPS(unittest.TestCase):
                 'method': 'trf',
                 'tr_solver': 'lsmr',
                 'x_scale': 'jac'}
-            fit.fitset = fitset
+            fit.lsq_kwargs = lsq_kwargs
 
             # call performfit to re-initialize _fnevals functions
             # (they might have been removed if symeninge has been used)
@@ -63,7 +63,7 @@ class TestDUMPS(unittest.TestCase):
 
     def test_performfit(self):
         # settings with whome the fit has been performed
-        fitset = {
+        lsq_kwargs = {
             'ftol': 1e-3,
             'gtol': 1e-3,
             'xtol': 1e-3,
@@ -76,7 +76,7 @@ class TestDUMPS(unittest.TestCase):
 
             print(f'testing plotfunctions for {msg} fit')
             fit = self.load_data(path)
-            fit.fitset = fitset
+            fit.lsq_kwargs = lsq_kwargs
             old_results = copy.deepcopy(fit.res_dict)
             print('testing performfit')
             fit.performfit()

--- a/tests/test_rtfit_dumps.py
+++ b/tests/test_rtfit_dumps.py
@@ -88,9 +88,9 @@ class TestDUMPS(unittest.TestCase):
             fit.performfit(fitset=fitset)
 
             for key, val in old_results.items():
-                self.assertTrue(np.allclose(fit.res_dict[key], val, atol=1e-4, rtol=1e-4),
+                self.assertTrue(np.allclose(np.repeat(*fit.res_dict[key]), val, atol=1e-4, rtol=1e-4),
                                 msg=f'fitted values for {msg} fit of {key} ' +
-                                     f'differ by {np.mean(fit.res_dict[key] - val)}')
+                                     f'differ by {np.mean(np.repeat(*fit.res_dict[key]) - val)}')
 
 
 

--- a/tests/test_rtfit_dumps.py
+++ b/tests/test_rtfit_dumps.py
@@ -33,11 +33,7 @@ class TestDUMPS(unittest.TestCase):
 
             print(f'testing plotfunctions for {msg} fit')
             fit = self.load_data(path)
-
             fitset = {
-                'int_Q': True,
-                '_fnevals_input': None,
-                'verbose': 0,
                 'ftol': 1e-3,
                 'gtol': 1e-3,
                 'xtol': 1e-3,
@@ -45,9 +41,11 @@ class TestDUMPS(unittest.TestCase):
                 'method': 'trf',
                 'tr_solver': 'lsmr',
                 'x_scale': 'jac'}
+            fit.fitset = fitset
+
             # call performfit to re-initialize _fnevals functions
             # (they might have been removed if symeninge has been used)
-            fit.performfit(fitset=fitset)
+            fit.performfit()
 
             # get list of available plot-methods
             method_list = [func for func in dir(fit.plot) if
@@ -66,9 +64,6 @@ class TestDUMPS(unittest.TestCase):
     def test_performfit(self):
         # settings with whome the fit has been performed
         fitset = {
-            'int_Q': True,
-            '_fnevals_input': None,
-            'verbose': 0,
             'ftol': 1e-3,
             'gtol': 1e-3,
             'xtol': 1e-3,
@@ -76,16 +71,15 @@ class TestDUMPS(unittest.TestCase):
             'method': 'trf',
             'tr_solver': 'lsmr',
             'x_scale': 'jac'}
-
         for path, msg in zip([self.sig0_dB_path, self.sig0_linear_path],
                              ['dB', 'linear']):
 
             print(f'testing plotfunctions for {msg} fit')
             fit = self.load_data(path)
-
+            fit.fitset = fitset
             old_results = copy.deepcopy(fit.res_dict)
             print('testing performfit')
-            fit.performfit(fitset=fitset)
+            fit.performfit()
 
             for key, val in old_results.items():
                 self.assertTrue(np.allclose(np.repeat(*fit.res_dict[key]), val, atol=1e-4, rtol=1e-4),

--- a/tests/test_rtfits.py
+++ b/tests/test_rtfits.py
@@ -230,7 +230,7 @@ class TestRTfits(unittest.TestCase):
         # estimates = fit[0].fun/weights + measurements
 
         estimates = np.reshape(
-                    fit[0].fun/weights, data.shape)
+                    res_lsq.fun/weights, data.shape)
 
         # apply mask
         measures = data[~mask]
@@ -267,7 +267,7 @@ class TestRTfits(unittest.TestCase):
                        't1': 0.09}
 
         for key in truevals:
-            err = abs(fit[6][key] - truevals[key]).mean()
+            err = abs(np.repeat(*res_dict[key]) - truevals[key]).mean()
             self.assertTrue(
                 err < errdict[key],
                 msg='derived error' + str(err) + 'too high for ' + str(key))

--- a/tests/test_rtfits.py
+++ b/tests/test_rtfits.py
@@ -204,15 +204,18 @@ class TestRTfits(unittest.TestCase):
                     }
 
         # perform fit
-        fit = testfit.monofit(V=V, SRF=SRF, dataset=dataset,
+        fit = testfit.monofit(V=V, SRF=SRF,
+                              dataset=dataset,
                               param_dict=param_dict,
                               bounds_dict=bounds_dict,
                               fixed_dict=fixed_dict,
                               param_dyn_dict=param_dyn_dict,
-                              verbose=2,
-                              ftol=1.e-8, xtol=1.e-8, gtol=1.e-8,
-                              x_scale='jac',
-                              max_nfev=500
+                              lsq_kwargs=dict(verbose=2,
+                                              ftol=1.e-8,
+                                              xtol=1.e-8,
+                                              gtol=1.e-8,
+                                              x_scale='jac',
+                                              max_nfev=500)
                               )
 
         # ----------- calculate R^2 values and errors of parameters -----------

--- a/tests/test_rtfits_performfit.py
+++ b/tests/test_rtfits_performfit.py
@@ -261,7 +261,7 @@ class TestRTfits(unittest.TestCase):
                        't1': 0.09}
 
         for key in truevals:
-            err = abs(testfit.res_dict[key] - truevals[key]).mean()
+            err = abs(np.repeat(*testfit.res_dict[key]) - truevals[key]).mean()
             self.assertTrue(
                 err < errdict[key],
                 msg='derived error' + str(err) + 'too high for ' + str(key))

--- a/tests/test_rtfits_performfit.py
+++ b/tests/test_rtfits_performfit.py
@@ -164,17 +164,13 @@ class TestRTfits(unittest.TestCase):
 
         # specify additional arguments for scipy.least_squares and rtfits.monofit
         fitset = {
-                'int_Q': True,
-                '_fnevals_input': None,
-                'verbose': 2,
                 'ftol': 1e-8,
                 'gtol': 1e-8,
                 'xtol': 1e-8,
                 'max_nfev': 500,
                 'method': 'trf',
                 'tr_solver': 'lsmr',
-                'x_scale': 'jac',
-                'intermediate_results':False}
+                'x_scale': 'jac'}
 
 
 
@@ -204,7 +200,8 @@ class TestRTfits(unittest.TestCase):
         testfit = Fits(sig0=sig0, dB=dB,
                        dataset=dataset, defdict=defdict,
                        set_V_SRF=set_V_SRF, fitset=fitset,
-                       setindex='mean')
+                       setindex='mean',
+                       int_Q=True, verbose=2)
 
         testfit.performfit()
 
@@ -222,7 +219,6 @@ class TestRTfits(unittest.TestCase):
         # sicne fit[0].fun gives the residuals weighted with respect to
         # weights, the model calculation can be gained via
         # estimates = fit[0].fun/weights + measurements
-
         estimates = np.reshape(
                     testfit.fit_output.fun/testfit.weights, testfit.data.shape)
 

--- a/tests/test_rtfits_performfit.py
+++ b/tests/test_rtfits_performfit.py
@@ -205,6 +205,10 @@ class TestRTfits(unittest.TestCase):
 
         testfit.performfit()
 
+        # check if _calc_slope_curv is working
+        # TODO this only tests if a result is obtained, not if the result
+        # is actually correct !!
+        slops, curvs = testfit._calc_slope_curv()
 
         # provide true-values for comparison of fitted results
         truevals = {'tau': taudata,

--- a/tests/test_rtfits_performfit.py
+++ b/tests/test_rtfits_performfit.py
@@ -163,7 +163,7 @@ class TestRTfits(unittest.TestCase):
 
 
         # specify additional arguments for scipy.least_squares and rtfits.monofit
-        fitset = {
+        lsq_kwargs = {
                 'ftol': 1e-8,
                 'gtol': 1e-8,
                 'xtol': 1e-8,
@@ -199,7 +199,7 @@ class TestRTfits(unittest.TestCase):
         # initialize fit-class
         testfit = Fits(sig0=sig0, dB=dB,
                        dataset=dataset, defdict=defdict,
-                       set_V_SRF=set_V_SRF, fitset=fitset,
+                       set_V_SRF=set_V_SRF, lsq_kwargs=lsq_kwargs,
                        setindex='mean',
                        int_Q=True, verbose=2)
 


### PR DESCRIPTION
- add RT1_configparser class
- add _init_V_SRF function to set V and SRF from config-file
- assign int_Q, lambda_backend, _fnevals_input as properties of the Fits object instead of providing them in the fitset-dict
- explicit lsq_kwargs dict added
    - new naming-convention *fit.fitset* -> *fit.lsq_kwargs*
- _assignvals function added to allow interpolation of values instead of using step-functions
    - parameters intended for interpolation can be assigned via Fits.interp_vals
- add res_df as property of Fits
- set data, inc, weights and mask as properties that are generated from dataset_used instead of storing the actual arrays (this saves memory when storing dumps)
