### PR TITLE
merge for v1.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,5 +53,5 @@ deploy:
     tags: true
 
 after_deploy:
-  #test installation from pip
+  # test installation from pip
   - pip install rt1

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,15 @@ after_success:
   - coveralls
 
 deploy:
+  # automatically deploy a release from the master-branch on pypi
   provider: pypi
   user: "__token__"
   password: $pypi_token
+  skip_existing: true
   on:
     branch: master
     tags: true
-    skip_existing: true
 
+after_deploy:
+  #test installation from pip
+  - pip install rt1

--- a/rt1/__init__.py
+++ b/rt1/__init__.py
@@ -2,5 +2,5 @@
 Import module for RT1 module
 """
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 __author__ = 'Raphael Quast'


### PR DESCRIPTION
- use v.1.1.1 instaead of v1.1.0 since 1.1.0 has unfortunately been deleted on pip already
- deploy releases from the master-branch automatically on pip