### PR TITLE
v1.1.2

### DIFF
--- a/rt1/rtfits.py
+++ b/rt1/rtfits.py
@@ -493,7 +493,6 @@ class Fits(Scatter):
         return np.array(list(map(int, conclist)))
 
 
-
     @property
     @lru_cache()
     def _N_groups(self):
@@ -662,15 +661,6 @@ class Fits(Scatter):
         '''
 
         return [i for i, v in self._startvaldict.items() if v is not None]
-
-
-    @property
-    def _max_rep(self):
-        '''
-        the maximum number of unique objects in the "_groupindex"
-        '''
-
-        return Counter(self._groupindex).most_common(1)[0][1]
 
 
     @property

--- a/rt1/rtfits.py
+++ b/rt1/rtfits.py
@@ -28,7 +28,6 @@ import ctypes
 from itertools import repeat, count
 from functools import lru_cache, partial
 from operator import itemgetter, add
-from collections import Counter
 
 from timeit import default_timer as tick
 from datetime import timedelta

--- a/rt1/rtfits.py
+++ b/rt1/rtfits.py
@@ -20,6 +20,7 @@ from .rtplots import plot as rt1_plots
 
 from . import surface as rt1_s
 from . import volume as rt1_v
+from . import __version__ as _RT1_version
 
 import copy
 import multiprocessing as mp
@@ -2246,6 +2247,8 @@ class Fits(Scatter):
 
             The default is True.
         '''
+        # add version number to dump
+        self._RT1_version = _RT1_version
 
         if mini is True:
             self._rt1_dump_mini = True


### PR DESCRIPTION
- avoid using concatenation where possible
- don't use pandas for evaluating _groupindex
- add version number to dump