### PR TITLE
Rtprocess

### DIFF
--- a/rt1/processing_config.py
+++ b/rt1/processing_config.py
@@ -12,7 +12,7 @@ from pathlib import Path
 class rt1_processing_config(object):
     '''
     a class that provides convenient default functions that can be used
-    with `rt1.rtfits.Fits.processfunc()`.
+    with `rt1.rtprocess.RTprocess`.
 
     Parameters
     ----------
@@ -33,48 +33,37 @@ class rt1_processing_config(object):
     Examples
     --------
 
-    >>> # subclass the configuration and add a reader
-    ... from rt1.processing_config import rt1_processing_config
-    ... from rt1.rtparse import RT1_configparser
+    >>> from rt1.processing_config import rt1_processing_config
     ...
     ... class run_configuration(rt1_processing_config):
     ...     def __init__(self, config_path, **kwargs):
     ...         super().__init__(**kwargs)
     ...         self.config_path = config_path
     ...
+    ...     # customize the preprocess function
+    ...     def preprocess(self, **kwargs):
+    ...         # run code prior to the init. of a multiprocessing.Pool
+    ...         ...
+    ...         return dict(reader_args=[dict(...), dict(...)],
+                            pool_kwargs=dict(...),
+                            ...)
+    ...
     ...     # add a reader-function
     ...     def reader(self, **reader_arg):
+    ...         # read the data for each fit
     ...         ...
+    ...         return df, aux_data
+    ...
+    ...     # customize the postprocess function
+    ...     def postprocess(self, fit, reader_arg):
+    ...         # do something with each fit and return the desired output
+    ...         return ...
+    ...
+    ...     # customize the finaloutput function
+    ...     def finaloutput(self, res):
+    ...         # do something with res
+    ...         # (res is a list of outputs from the postprocess() function)
     ...         ...
-    ...         return df
-    ...
-    ...     # add a function to initialize the processing
-    ...     def run_procesing(self, reader_args, ncpu):
-    ...
-    ...         # get fit object by using a config-file
-    ...         fitobject = RT1_configparser(self.config_path).get_fitobject()
-    ...
-    ...         res = fitobject.processfunc(ncpu=ncpu,
-    ...                                     reader_args=reader_args,
-    ...                                     reader=self.reader,
-    ...                                     preprocess=self.preprocess,
-    ...                                     postprocess=self.postprocess,
-    ...                                     exceptfunc=self.exceptfunc,
-    ...                                     finaloutput=self.finaloutput
-    ...                                     )
-    ...
-    ... # the final function to be called within '__main__'
-    ... def run(config_path, reader_args, ncpu):
-    ...
-    ...     cfg = RT1_configparser(config_path)
-    ...     # get paths etc. from config-file
-    ...     spec = cfg.get_process_specs()
-    ...
-    ...     proc = run_configuration(config_path=config_path,
-    ...                              save_path=spec['save_path'],
-    ...                              dumpfolder=spec['dumpfolder'],
-    ...                              finalout_name=spec['finalout_name'])
-    ...     proc.run_procesing(reader_args=reader_args, ncpu=ncpu)
 
     '''
 

--- a/rt1/processing_config.py
+++ b/rt1/processing_config.py
@@ -118,41 +118,11 @@ class rt1_processing_config(object):
         return feature_id, filename, error_filename
 
 
-    def preprocess(self):
+    def preprocess(self, **kwargs):
         '''
         a function that is called PRIOR to processing that does the following:
-            - create the folder-structure if it does not yet exist
-
-        the introduced folder-structure is:
-        - "save-path"
-            - dumps -> folder where dump-files will be stored
-            - results -> folder where finalouput-files will be stored
-            - cfg -> folder where additional processing files will be saved
-
-        Parameters
-        ----------
-        reader_arg : dict
-            the arguments passed to the reader.
-
         '''
-        if self.save_path is not None and self.dumpfolder is not None:
-            # generate "save_path" directory if it does not exist
-            if not self.save_path.exists():
-                print(self.save_path, 'does not exist... creating directory')
-                self.save_path.mkdir()
-
-            # generate "dumps" directory if it does not exist
-            dumppath = self.save_path / self.dumpfolder / 'dumps'
-            if not dumppath.exists():
-                print(dumppath, 'does not exist... creating directory')
-                dumppath.mkdir(parents=True)
-
-            # generate "results" directory if it does not exist
-            respath = self.save_path / self.dumpfolder / 'results'
-            if not respath.exists():
-                print(respath, 'does not exist... creating directory')
-                respath.mkdir()
-
+        return
 
     def postprocess(self, fit, reader_arg):
         '''

--- a/rt1/processing_config.py
+++ b/rt1/processing_config.py
@@ -113,7 +113,7 @@ class rt1_processing_config(object):
         filename = f"{feature_id}.dump"
 
         # the filename of the error-dumpfile
-        error_filename = f"{feature_id}_error.dump"
+        error_filename = f"{feature_id}_error.txt"
 
         return feature_id, filename, error_filename
 

--- a/rt1/processing_config.py
+++ b/rt1/processing_config.py
@@ -151,12 +151,14 @@ class rt1_processing_config(object):
             if not self.save_path.exists():
                 print(self.save_path, 'does not exist... creating directory')
                 self.save_path.mkdir()
-            # generate "dumpfs" directory if it does not exist
+
+            # generate "dumps" directory if it does not exist
             dumppath = self.save_path / self.dumpfolder / 'dumps'
             if not dumppath.exists():
                 print(dumppath, 'does not exist... creating directory')
                 dumppath.mkdir(parents=True)
 
+            # generate "results" directory if it does not exist
             respath = self.save_path / self.dumpfolder / 'results'
             if not respath.exists():
                 print(respath, 'does not exist... creating directory')
@@ -202,8 +204,6 @@ class rt1_processing_config(object):
             # if no dump exists, dump it, else load the existing dump
             if not dumppath.exists():
                 fit.dump(dumppath, mini=True)
-                #print(datetime.now().strftime('%d-%b-%Y %H:%M:%S'),
-                #      'finished', feature_id)
 
         # get resulting parameter DataFrame
         df = fit.res_df

--- a/rt1/processing_config.py
+++ b/rt1/processing_config.py
@@ -56,7 +56,7 @@ class rt1_processing_config(object):
     ...                     ...)
     ...
     ...     # add a reader-function
-    ...     def reader(self, reader_arg):
+    ...     def reader(self, **reader_arg):
     ...         # read the data for each fit
     ...         ...
     ...         return df, aux_data
@@ -125,6 +125,16 @@ class rt1_processing_config(object):
         return feature_id, filename, error_filename
 
 
+    def check_dump_exists(self, reader_arg):
+        # check if the file already exists, and if yes, raise a skip-error
+        feature_id, fname, error_fname = self.get_names_ids(reader_arg)
+        if self.save_path is not None and self.dumpfolder is not None:
+            dumppath = self.save_path / self.dumpfolder / 'dumps' / fname
+
+            if dumppath.exists():
+                raise Exception('rt1_file_already_exists')
+
+
     def preprocess(self, **kwargs):
         '''
         a function that is called PRIOR to processing that does the following:
@@ -162,15 +172,17 @@ class rt1_processing_config(object):
 
         '''
 
-        # set filenames
+        # get filenames
         feature_id, fname, error_fname = self.get_names_ids(reader_arg)
 
+        # make a dump of the fit
+        feature_id, fname, error_fname = self.get_names_ids(reader_arg)
         if self.save_path is not None and self.dumpfolder is not None:
-            dumppath = self.save_path.joinpath(self.dumpfolder, 'dumps', fname)
+            dumppath = self.save_path / self.dumpfolder / 'dumps' / fname
 
-            # if no dump exists, dump it, else load the existing dump
             if not dumppath.exists():
                 fit.dump(dumppath, mini=True)
+
 
         # get resulting parameter DataFrame
         df = fit.res_df

--- a/rt1/processing_config.py
+++ b/rt1/processing_config.py
@@ -36,9 +36,16 @@ class rt1_processing_config(object):
     >>> from rt1.processing_config import rt1_processing_config
     ...
     ... class run_configuration(rt1_processing_config):
-    ...     def __init__(self, config_path, **kwargs):
+    ...     def __init__(self, **kwargs):
     ...         super().__init__(**kwargs)
-    ...         self.config_path = config_path
+    ...
+    ...     # customize the naming of the output-files
+    ...     def get_names_ids(self, reader_arg):
+    ...         # run code prior to the init. of a multiprocessing.Pool
+    ...         ...
+    ...         return dict(reader_args=[dict(...), dict(...)],
+    ...                     pool_kwargs=dict(...),
+    ...                     ...)
     ...
     ...     # customize the preprocess function
     ...     def preprocess(self, **kwargs):
@@ -49,7 +56,7 @@ class rt1_processing_config(object):
     ...                     ...)
     ...
     ...     # add a reader-function
-    ...     def reader(self, **reader_arg):
+    ...     def reader(self, reader_arg):
     ...         # read the data for each fit
     ...         ...
     ...         return df, aux_data

--- a/rt1/rtparse.py
+++ b/rt1/rtparse.py
@@ -339,10 +339,17 @@ class RT1_configparser(object):
         return rt1_fits
 
 
-    def get_all_modules(self, load_copy=True):
+    def get_all_modules(self, load_copy=False):
         '''
         programmatically import all defined modules from the paths provided
         in the [CONFIGFILES] section
+
+        Parameters
+        ----------
+        load_copy : bool, optional
+            indicator if the modules should be loaded from the specified path
+            or if it should be loaded from "save_path/dumpfolder/cfg".
+            The default is False.
 
         Returns
         -------
@@ -362,10 +369,20 @@ class RT1_configparser(object):
         return processmodules
 
 
-    def get_module(self, modulename, load_copy=True):
+    def get_module(self, modulename, load_copy=False):
         '''
         programmatically import the module 'modulename' as described here:
         https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
+
+
+        Parameters
+        ----------
+        modulename : str
+            the module-name (e.g. the key specified in the ".ini"-file).
+        load_copy : bool, optional
+            indicator if the module should be loaded from the specified path
+            or if it should be loaded from "save_path/dumpfolder/cfg".
+            The default is False.
 
         Returns
         -------

--- a/rt1/rtprocess.py
+++ b/rt1/rtprocess.py
@@ -1,0 +1,742 @@
+import multiprocessing as mp
+from timeit import default_timer
+from datetime import timedelta
+from itertools import repeat
+import ctypes
+
+from pathlib import Path
+import shutil
+
+import pandas as pd
+from numpy.random import randint as np_randint
+
+from .general_functions import dt_to_hms, update_progress
+from .rtparse import RT1_configparser
+from .rtfits import load
+
+
+try:
+    import xarray as xar
+except:
+    print('xarray could not imported,',
+          'NetCDF-features of RT1_results will not work!')
+
+try:
+    from netCDF4 import Dataset
+except:
+    print('netCDF4.Dataset could not imported,',
+          'some NetCDF-features of RT1_results will not work!')
+
+
+def _confirm_input(msg='are you sure?', stopmsg='STOP', callbackdict=None):
+    '''
+    Parameters
+    ----------
+    msg : str, optional
+        The prompt message. The default is 'are you sure?'.
+    stopmsg : str, optional
+        The message displayed if the answer is False. The default is 'STOP'.
+    callbackdict : dict, optional
+        A dict of the form {key: [msg, callback]} . The default is None.
+    '''
+    default_answers = {"YES": True, "Y": True, "NO": False, "N": False}
+
+    # prompt input
+    inp = str(input(msg)).upper()
+
+    # in case the input is found in the callback-dict, ask for confirmation
+    # and execute the callback
+    if inp in callbackdict:
+        cbmsg, cb = callbackdict[inp]
+        inp2 = str(input(cbmsg)).upper()
+        print()
+        answer2 = default_answers.get(inp2, False)
+        if answer2 is False:
+            print(stopmsg)
+            exit(0)
+            return
+        cb()
+    else:
+        answer = default_answers.get(inp, False)
+        if answer is False:
+            print(stopmsg)
+            print()
+            exit(0)
+            return
+
+
+def _make_folderstructure(save_path, subfolders):
+    if save_path is not None:
+        # generate "save_path" directory if it does not exist
+        if not save_path.exists():
+            print(f'"{save_path}"\ndoes not exist... creating directory')
+            save_path.mkdir(parents=True)
+
+        for folder in subfolders:
+        # generate subfolder if it does not exist
+            mkpath = save_path / folder
+            if not mkpath.exists():
+                print(f'"{mkpath}"\ndoes not exist... creating directory')
+                mkpath.mkdir(parents=True)
+
+
+
+class RTprocess(object):
+    def __init__(self, config_path=None,
+                 proc_cls=None, parent_fit=None,
+                 init_kwargs=None, copy=True):
+
+        if config_path is not None and proc_cls is None:
+            self.config_path = Path(config_path)
+            assert self.config_path.exists(), (f'the file {self.config_path} '
+                                               + 'does not exist!')
+
+            self.cfg = RT1_configparser(config_path)
+            specs = self.cfg.get_process_specs()
+
+            self.dumppath = specs['save_path'] / specs['dumpfolder']
+
+            if self.dumppath.exists():
+                def remove_folder():
+                    shutil.rmtree(specs['save_path'] / specs['dumpfolder'])
+
+                _confirm_input(
+                    msg=(f'the path \n "{self.dumppath}"\n already exists...' +
+                         '\n- to continue type YES or Y' +
+                         '\n- to abort type NO or N' +
+                         '\n- to remove the existing directory and all' +
+                         'subdirectories type REMOVE \n \n'),
+                    callbackdict={'REMOVE':[
+                        (f'\n"{self.dumppath}"\n will be removed!' +
+                         ' are you sure? (y, n): '),
+                        remove_folder]})
+
+            # initialize the folderstructure
+            _make_folderstructure(specs['save_path'] / specs['dumpfolder'],
+                                  ['results', 'cfg', 'dumps'])
+
+            if copy is True:
+                self._copy_cfg_and_modules()
+
+            # load the processing-class
+            if 'processing_cfg_module' in specs:
+                proc_module_name = specs['processing_cfg_module']
+            else:
+                proc_module_name = 'processing_cfg'
+
+            if 'processing_cfg_class' in specs:
+                proc_class_name = specs['processing_cfg_class']
+            else:
+                proc_class_name = 'processing_cfg'
+
+            procmodule = self.cfg.get_all_modules(
+                load_copy=copy)[proc_module_name]
+            print(f'processing config class "{proc_class_name}" will be ' +
+                  f'imported from \n"{procmodule}"')
+
+            self.proc_cls = getattr(procmodule, proc_class_name)(
+                **getattr(self, 'init_kwargs', dict()))
+
+            # make all arguments provided in [PROCESS SPECS] accessible to
+            # the processing-class
+            for key, val in specs.items():
+                if hasattr(self.proc_cls, key):
+                    print(f'warning, "{key}={getattr(self, key)}" will be ',
+                          'overwritten by the definition provided in the .ini',
+                          f'file "{key} = {val}" ')
+
+                setattr(self.proc_cls, key, val)
+
+            # get the parent fit-object
+            if parent_fit is None:
+                parent_fit = self.cfg.get_fitobject()
+
+
+        # check if all necessary functions are defined in the  processing-class
+        for key in ['preprocess', 'reader', 'postprocess', 'finaloutput',
+                    'exceptfunc']:
+            assert hasattr(self.proc_cls, key), (
+                f'a function {key}() MUST be provided in the config-class!')
+
+        assert parent_fit is not None, (
+            'you MUST provide a valid config-file or a parent_fit-object!')
+
+        self.parent_fit = parent_fit
+
+
+    def _copy_cfg_and_modules(self):
+        # if copy is True, copy the config-file and re-import the cfg
+        # from the copied file
+            copypath = self.dumppath / 'cfg' / self.cfg.configpath.name
+            if (copypath).exists():
+                print(f'the file \n"{copypath / self.cfg.configpath.name}"\n' +
+                      'already exists... NO copying is performed and the ' +
+                      'existing one is used!\n')
+            else:
+                shutil.copy(self.cfg.configpath, copypath.parent)
+                print(f'"{self.cfg.configpath.name}" copied to\n' +
+                      f'"{copypath.parent}"')
+
+                # remove the config and re-read the config from the copied path
+                del self.cfg
+                self.cfg = RT1_configparser(copypath)
+
+
+            # copy modules
+            for key, val in self.cfg.config['CONFIGFILES'].items():
+                if key.startswith('module__'):
+                    modulename = key[8:]
+
+                    module_path = self.cfg.config[
+                        'CONFIGFILES'][f'module__{modulename}']
+
+                    location = Path(module_path.strip())
+
+                    copypath = self.dumppath / 'cfg' / location.name
+
+                    if copypath.exists():
+                        print(f'the file \n"{copypath}" \nalready ' +
+                              'exists ... NO copying is performed ' +
+                              'and the existing one is used!\n')
+                    else:
+                        shutil.copy(location, copypath)
+                        print(f'"{location.name}" copied to \n"{copypath}"')
+
+
+
+    def _evalfunc(self, reader_arg=None, process_cnt=None):
+        """
+        Initialize a Fits-instance and perform a fit.
+        (used for parallel processing)
+
+        Parameters
+        ----------
+        reader_arg : dict
+            A dict of arguments passed to the reader.
+
+        Returns
+        -------
+        The used 'rt1.rtfit.Fits' object or the output of 'postprocess()'
+        """
+        if process_cnt is not None:
+            start = default_timer()
+        try:
+            # if a reader (and no dataset) is provided, use the reader
+            read_data = self.proc_cls.reader(**reader_arg)
+            # check for multiple return values and split them accordingly
+            # (any value beyond the first is appended as aux_data)
+            if isinstance(read_data, pd.DataFrame):
+                dataset = read_data
+                aux_data = None
+            elif (isinstance(read_data, (list, tuple))
+                  and isinstance(read_data[0], pd.DataFrame)):
+                if len(read_data) == 2:
+                    dataset, aux_data = read_data
+                elif  len(read_data) > 2:
+                    dataset = read_data[0]
+                    aux_data = read_data[1:]
+            else:
+                raise TypeError('the first return-value of reader function ' +
+                                'must be a pandas DataFrame')
+            # initialize a new fits-object and perform the fit
+            fit = self.parent_fit.reinit_object(dataset=dataset)
+            fit.performfit()
+
+            # append auxiliary data
+            if aux_data is not None:
+                fit.aux_data = aux_data
+
+            # append reader_arg
+            fit.reader_arg = reader_arg
+
+            # if a post-processing function is provided, return its output,
+            # else return the fit-object directly
+            if callable(self.proc_cls.postprocess):
+                ret = self.proc_cls.postprocess(fit, reader_arg)
+            else:
+                ret = fit
+
+            if process_cnt is not None:
+                p_totcnt, p_meancnt, p_max, p_time, p_ncpu = process_cnt
+                end = default_timer()
+                # increase the total counter
+                p_totcnt.value += 1
+
+                # update the estimate of the mean time needed to process a site
+                p_time.value = (p_meancnt.value * p_time.value
+                                + (end - start)) / (p_meancnt.value + 1)
+                # increase the mean counter
+                p_meancnt.value += 1
+                # get the remaining time and update the progressbar
+                remain = timedelta(
+                    seconds = (p_max - p_totcnt.value) / p_ncpu * p_time.value)
+                d,h,m,s = dt_to_hms(remain)
+                update_progress(
+                    p_totcnt.value, p_max,
+                    title=f"approx. {d} {h:02}:{m:02}:{s:02} remaining",
+                    finalmsg="finished! " + \
+                        f"({p_max} [{p_totcnt.value - p_meancnt.value}] fits)",
+                    progress2=p_totcnt.value - p_meancnt.value)
+
+            return ret
+
+        except Exception as ex:
+            if process_cnt is not None:
+                p_totcnt, p_meancnt, p_max, p_time, p_ncpu = process_cnt
+                # only increase the total counter
+                p_totcnt.value += 1
+                if p_meancnt.value == 0:
+                    title=f"{'estimating time ...':<28}"
+                else:
+                    # get the remaining time and update the progressbar
+                    remain = timedelta(
+                        seconds = (p_max - p_totcnt.value
+                                   ) / p_ncpu * p_time.value)
+                    d,h,m,s = dt_to_hms(remain)
+                    title=f"approx. {d} {h:02}:{m:02}:{s:02} remaining"
+
+                update_progress(
+                    p_totcnt.value, p_max,
+                    title=title,
+                    finalmsg="finished! " + \
+                        f"({p_max} [{p_totcnt.value - p_meancnt.value}] fits)",
+                    progress2=p_totcnt.value - p_meancnt.value)
+
+            if callable(self.proc_cls.exceptfunc):
+                return self.proc_cls.exceptfunc(ex, reader_arg)
+            else:
+                raise ex
+
+
+    def processfunc(self, ncpu=1, print_progress=True,
+                    reader_args=None, pool_kwargs=None,
+                    preprocess_kwargs=None):
+        """
+        Evaluate a RT-1 model on a single core or in parallel using either
+            - a list of datasets or
+            - a reader-function together with a list of arguments that
+              will be used to read the datasets
+
+        Notice:
+            On Windows, if multiprocessing is used, you must protect the call
+            of this function via:
+            (see for example: )
+
+            >>> if __name__ == '__main__':
+                    fit.processfunc(...)
+
+            In order to allow pickling the final rt1.rtfits.Fits object,
+            it is required to store ALL definitions within a separate
+            file and call processfunc in the 'main'-file as follows:
+
+            >>> from specification_file import fit reader lsq_kwargs ... ...
+                if __name__ == '__main__':
+                    fit.processfunc(ncpu=5, reader=reader,
+                                    lsq_kwargs=lsq_kwargs, ... ...)
+
+        Parameters
+        ----------
+        ncpu : int, optional
+            The number of kernels to use. The default is 1.
+        reader : callable, optional
+            A function whose first return-value is a pandas.DataFrame that can
+            be used as a 'dataset'. (see documentation of 'rt1.rtfits.Fits'
+            for details on how to properly specify a RT-1 dataset).
+            Any additional (optional) return-values will be appended to the
+            Fits-object in the 'aux_data' attribute. The default is None.
+        reader_args : list, optional
+            A list of dicts that will be passed to the reader-function.
+            The default is None.
+        lsq_kwargs : dict, optional
+            override the lsq_kwargs-dict of the parent Fits-object.
+            (see documentation of 'rt1.rtfits.Fits')
+            The default is None.
+        preprocess : callable
+            A function that will be called prior to the start of the processing
+            It is called via:
+
+            >>> preprocess()
+        postprocess : callable
+            A function that accepts a rt1.rtfits.Fits object and a dict
+            as arguments and returns any desired output.
+
+            Internally it is called after calling performfit() via:
+
+            >>> ...
+            >>> fit.performfit()
+            >>> return postprocess(fit, reader_arg)
+        exceptfunc : callable, optional
+            A function that is called in case an exception occurs.
+            It is (roughly) implemented via:
+
+            >>> for reader_arg in reader_args:
+            >>>     try:
+            >>>         ...
+            >>>         ... perform fit ...
+            >>>         ...
+            >>>     except Exception as ex:
+            >>>         exceptfunc(ex, reader_arg)
+
+            The default is None, in which case the exception will be raised.
+        finaloutput : callable, optional
+            A function that will be called on the list of returned objects
+            after the processing has been finished.
+        pool_kwargs : dict
+            A dict with additional keyword-arguments passed to the
+            initialization of the multiprocessing-pool via:
+
+            >>> mp.Pool(ncpu, **pool_kwargs)
+        print_progress : bool
+            indicator if a progress-bar should be printed to stdout or not
+            that looks like this:
+
+            >>> approx. 0 00:00:02 remaining ################------ 3 (2) / 4
+            >>>
+            >>> (estimated time day HH:MM:SS)(     progress bar   )( counts )
+            >>> ( counts ) = finished fits [actually fitted] / total
+
+        Returns
+        -------
+        res : list
+            A list of rt1.rtfits.Fits objects or a list of outputs of the
+            postprocess-function.
+
+        """
+
+        if callable(self.proc_cls.preprocess):
+            setupdict = self.proc_cls.preprocess(**preprocess_kwargs)
+            assert isinstance(setupdict, dict), (
+                'the preprocess() function must return a dict!')
+        else:
+            setupdict = dict()
+
+        # check if reader args is provided in setupdict
+        if reader_args is None:
+            assert 'reader_args' in setupdict, (
+                'if "reader_args" is not passed directly to processfunc() ' +
+                ', the preprocess() function must return a key "reader_args"!')
+
+            reader_args = setupdict['reader_args']
+        else:
+            assert 'reader_args' not in setupdict, (
+            '"reader_args" is provided as argument to processfunc() ' +
+            'AND via the return-dict of the preprocess() function!')
+
+        print(f'processing {len(setupdict["reader_args"])} features')
+
+
+        if 'pool_kwargs' in setupdict:
+            pool_kwargs = setupdict['pool_kwargs']
+
+        if pool_kwargs is None: pool_kwargs = dict()
+
+        if self.parent_fit.int_Q is True:
+            # pre-evaluate the fn-coefficients if interaction terms are used
+            self.parent_fit._fnevals_input = self.parent_fit.R._fnevals
+
+
+        if print_progress is True:
+            # initialize shared values that will be used to track the number
+            # of completed processes and the mean time to complete a process
+            manager = mp.Manager()
+            p_totcnt = manager.Value(ctypes.c_ulonglong, 0)
+            p_meancnt = manager.Value(ctypes.c_ulonglong, 0)
+            p_time = manager.Value(ctypes.c_float, 0)
+            process_cnt = [p_totcnt, p_meancnt, len(reader_args),
+                           p_time, ncpu]
+        else:
+            process_cnt = None
+
+        if ncpu > 1:
+            print('start of parallel evaluation')
+            with mp.Pool(ncpu, **pool_kwargs) as pool:
+                # loop over the reader_args
+                res_async = pool.starmap_async(self._evalfunc,
+                                               zip(reader_args,
+                                                   repeat(process_cnt)))
+
+                pool.close()  # Marks the pool as closed.
+                pool.join()   # Waits for workers to exit.
+                res = res_async.get()
+        else:
+            print('start of single-core evaluation')
+            res = []
+            for reader_arg in reader_args:
+                res.append(self._evalfunc(reader_arg=reader_arg,
+                                          process_cnt=process_cnt))
+
+        if callable(self.proc_cls.finaloutput):
+            return self.proc_cls.finaloutput(res)
+        else:
+            return res
+
+
+    def run_processing(self, ncpu, print_progress=True,
+                       preprocess_kwargs=None):
+        '''
+        Start the processing
+
+        Parameters
+        ----------
+        ncpu : int
+            The number of cpu's to use.
+        print_progress : bool, optional
+            Indicator if a progress-bar should be printed or not.
+            If True, it might be wise to suppress warnings during runtime
+            to avoid unwanted outputs. This can be achieved by using:
+
+                >>> import warnings
+                ... warnings.simplefilter('ignore')
+
+            The default is True.
+        preprocess_kwargs : dict, optional
+            A dict containing keyword-arguments that will be passed to
+            the preprocess function via `preprocess(**preprocess_kwargs)`.
+            The default is None.
+
+        '''
+        print('############################################################\n')
+        if preprocess_kwargs is None:
+            preprocess_kwargs = dict()
+
+        print(self.parent_fit._model_definition,
+              file=open(self.cfg.get_process_specs()['save_path'] /
+                        self.cfg.get_process_specs()['dumpfolder'] /
+                        'cfg' / 'model_definition.txt', 'w'))
+
+        _ = self.processfunc(ncpu=ncpu, print_progress=print_progress,
+                             preprocess_kwargs=preprocess_kwargs)
+
+
+
+class RT1_results(object):
+    '''
+    A class to provide easy access to processed results.
+    On initialization the class will traverse the provided "parent_path"
+    and recognize any sub-folder that matches the expected folder-structure
+    as a sub-result.
+
+
+    Assuming a folder-structure as indicated below, the class can be used via:
+
+        >>> ../../RESULTS      (parent_path)
+        ...     results/..     (.nc files)
+        ...     dumps/..       (.dump files)
+        ...     cfg/..         (.ini files)
+        ...
+        ...     sub_RESULT1
+        ...         results/.. (.nc files)
+        ...         dumps/..   (.dump files)
+        ...         cfg/..     (.ini files)
+        ...
+        ...     sub_RESULT2
+        ...         ....
+
+
+        >>> results = RT1_results(parent_path)
+        ... # print available NetCDF files and variables
+        ... x.RESULTS.NetCDF_variables
+        ... x.sub_RESULT_1.NetCDF_variables
+        ...
+        ... # load some dump-files
+        ... fit_random = results.sub_RESULT_1.load_fit()
+        ... fit1_0 = results.RESULT.load_fit('id_of_fit_1')
+        ... fit1_1 = results.sub_RESULT_1.load_fit('id_of_fit_1')
+        ... fit1_2 = results.sub_RESULT_2.load_fit('id_of_fit_1')
+        ...
+        ... # access a NetCDF file
+        ... with results.sub_RESULT_2.load_nc() as ncfile:
+        ...     --- read something from the ncfie ---
+        ...
+        ... # get a generator for the paths of all available dump-files
+        ... dump-files = results.sub_RESULT_1.dump_files
+        ...
+        ... # load the configfile of a given fit
+        ... cfg_01 = results.sub_RESULT_1.load_cfg()
+
+
+    Parameters
+    ----------
+    parent_path : str
+        the parent-path where the results are stored.
+    '''
+
+    def __init__(self, parent_path):
+        self._parent_path = Path(parent_path)
+
+        self._paths = dict()
+
+        if all(i in [i.stem for i in self._parent_path.iterdir()]
+               for i in ['cfg', 'results', 'dumps']):
+            self._paths[self._parent_path.stem] = self._parent_path
+            print('... adding result', self._parent_path.stem)
+            setattr(self, self._parent_path.stem,
+                    self._RT1_fitresult(self._parent_path.stem,
+                                        self._parent_path))
+
+        for p in self._parent_path.iterdir():
+            if p.is_dir():
+                if all(i in [i.stem for i in p.iterdir()]
+                       for i in ['cfg', 'results', 'dumps']):
+                    self._paths[p.stem] = p
+                    print('... adding result', p.stem)
+                    setattr(self, p.stem,
+                            self._RT1_fitresult(p.stem, p))
+
+    class _RT1_fitresult(object):
+            def __init__(self, name, path):
+                self.name = name
+                self.path = Path(path)
+                self._result_path = self.path / 'results'
+                self._dump_path = self.path / 'dumps'
+                self._cfg_path = self.path / 'cfg'
+
+
+            def _get_results(self, ending):
+                assert self._result_path.exists(), f'{self._result_path}' + \
+                    ' does not exist'
+
+                results = {i.stem : i for i in self._result_path.iterdir()
+                           if i.suffix == ending}
+
+                assert len(results) > 0, f'there is no "{ending}" file' + \
+                    f' in "{self._result_path}"'
+
+                return results
+
+
+            def load_nc(self, result_name=None, use_xarray=True):
+                '''
+                open a NetCDF file stored in the "results"-folder
+
+                can be used as context-manager, e.g.:
+
+                    >>> with result.load_nc() as ncfile:
+                    ...     --- do something ---
+
+
+                Parameters
+                ----------
+                result_name : str, optional
+                    The name of the NetCDF-file (without a .nc extension).
+                    If None, and only 1 file is available, the available file
+                    will be laoded. The default is None.
+                use_xarray : bool, optional
+                    Indicator if NetCDF4 or xarray should be used to
+                    laod the NetCDF file. The default is True.
+
+                Returns
+                -------
+                file : a file-handler for the NetCDF file
+                    the return of either xarray.Dataset or NetCDF4.Dataset
+                '''
+                results = self._get_results('.nc')
+
+                assert len(results) == 1 or result_name in results, (
+                     ('there is more than 1 result... ' +
+                      'provide "result_name":\n    - ' +
+                      '\n    - '.join(results.keys())))
+
+                if result_name is None:
+                     result_name = list(results.keys())[0]
+
+                #print(f'loading nc-file for {result_name}')
+                if use_xarray is True:
+                    file = xar.open_dataset(results[result_name])
+                else:
+                    file = Dataset(results[result_name])
+                return file
+
+
+            def load_fit(self, ID=None):
+                '''
+                load one of the available .dump-files located in the "dumps"
+                folder.  (using rt1.rtfits.load() )
+
+                Notice: the dump-files are generated using cloudpickle.dump()
+                and might be platform and environment-specific!
+
+                Parameters
+                ----------
+                ID : str, optional
+                    The name of the dump-file to be loaded (without the .dump
+                    extension). If None, a random file will be selected.
+                    The default is None.
+
+                Returns
+                -------
+                fit : rt1.rtfits.Fits
+                    the loaded rt1.rtfits.Fits result.
+                '''
+
+                if ID is None:
+                    allfiles = list(self.dump_files)
+                    Nid = np_randint(0, len(allfiles) -1)
+
+                    ID = allfiles[Nid].stem
+                    print(f'loading random ID ({ID}) from {len(allfiles)} ' +
+                          'available files')
+
+                fit = load(self._dump_path / (ID + '.dump'))
+                return fit
+
+
+            def load_cfg(self, cfg_name=None):
+                '''
+                load the configfile stored in the "cfg" folder
+
+                Parameters
+                ----------
+                cfg_name : str, optional
+                    The name of the config-file to laod in case more than 1
+                    ".ini"-files are found. The default is None.
+
+                Returns
+                -------
+                cfg : rt1.rtparse.RT1_configparser
+                    a configparser instance of the selected configuration.
+
+                '''
+                cfgfiles = list(self._cfg_path.glob('*.ini'))
+                assert len(cfgfiles) > 0, 'NO ".ini"-file found!'
+
+                if cfg_name is None:
+                    assert len(cfgfiles) == 1, (
+                        'there is more than 1 .ini file in the cfg folder...' +
+                        'provide a "cfg_name":\n' +
+                        '    - ' + '\n    - '.join([i.name for i in cfgfiles]))
+
+                    cfg_name = cfgfiles[0].name
+
+                cfg = RT1_configparser(self._cfg_path / cfg_name)
+                return cfg
+
+
+            @property
+            def dump_files(self):
+                '''
+                a generator of the available dump-files
+                '''
+                return self._dump_path.iterdir()
+
+
+            @property
+            def NetCDF_variables(self):
+                '''
+                print all available NetCDF-files and their variables
+                '''
+                results = self._get_results('.nc')
+
+                for r in results:
+                    print('\nresult: ', r)
+                    with self.load_nc(r, use_xarray=False) as ncfile:
+                        space = len(max(ncfile.variables.keys(), key=len))
+                        for key, val in ncfile.variables.items():
+                            if key in ncfile.dimensions.keys():
+                                print(f'dimension: ', *zip(val.dimensions,
+                                                           val.shape))
+                            else:
+                                print(f'{key:<{space + 7}}', val.dimensions)
+
+
+

--- a/rt1/rtprocess.py
+++ b/rt1/rtprocess.py
@@ -504,10 +504,10 @@ class RTprocess(object):
         if preprocess_kwargs is None:
             preprocess_kwargs = dict()
 
-        print(self.parent_fit._model_definition,
-              file=open(self.cfg.get_process_specs()['save_path'] /
-                        self.cfg.get_process_specs()['dumpfolder'] /
-                        'cfg' / 'model_definition.txt', 'w'))
+        with open(self.cfg.get_process_specs()['save_path'] /
+                  self.cfg.get_process_specs()['dumpfolder'] /
+                  'cfg' / 'model_definition.txt', 'w') as file:
+            print(self.parent_fit._model_definition, file=file)
 
         _ = self.processfunc(ncpu=ncpu, print_progress=print_progress,
                              reader_args=reader_args, pool_kwargs=pool_kwargs,
@@ -515,7 +515,7 @@ class RTprocess(object):
 
 
 
-class RT1_results(object):
+class RTresults(object):
     '''
     A class to provide easy access to processed results.
     On initialization the class will traverse the provided "parent_path"

--- a/rt1/rtprocess.py
+++ b/rt1/rtprocess.py
@@ -119,7 +119,8 @@ class RTprocess(object):
         perform necessary tasks to run a processing-routine
           - initialize the folderstructure
           - copy modules and .ini files (if copy=True)
-          -
+          - load modules and set parent-fit-object
+
         Parameters
         ----------
         copy : bool

--- a/rt1/rtprocess.py
+++ b/rt1/rtprocess.py
@@ -724,7 +724,8 @@ class RTresults(object):
                 '''
                 a generator of the available dump-files
                 '''
-                return self._dump_path.iterdir()
+                return (i for i in self._dump_path.iterdir()
+                        if i.suffix == '.dump' and 'error' not in i.stem)
 
 
             @property

--- a/rt1/rtprocess.py
+++ b/rt1/rtprocess.py
@@ -70,14 +70,14 @@ def _make_folderstructure(save_path, subfolders):
         # generate "save_path" directory if it does not exist
         if not save_path.exists():
             print(f'"{save_path}"\ndoes not exist... creating directory')
-            save_path.mkdir(parents=True)
+            save_path.mkdir(parents=True, exist_ok=True)
 
         for folder in subfolders:
         # generate subfolder if it does not exist
             mkpath = save_path / folder
             if not mkpath.exists():
                 print(f'"{mkpath}"\ndoes not exist... creating directory')
-                mkpath.mkdir(parents=True)
+                mkpath.mkdir(parents=True, exist_ok=True)
 
 
 

--- a/rt1/rtprocess.py
+++ b/rt1/rtprocess.py
@@ -3,6 +3,7 @@ from timeit import default_timer
 from datetime import timedelta
 from itertools import repeat
 import ctypes
+import sys
 
 from pathlib import Path
 import shutil
@@ -53,7 +54,7 @@ def _confirm_input(msg='are you sure?', stopmsg='STOP', callbackdict=None):
         answer2 = default_answers.get(inp2, False)
         if answer2 is False:
             print(stopmsg)
-            exit(0)
+            sys.exit(0)
             return
         cb()
     else:
@@ -61,7 +62,7 @@ def _confirm_input(msg='are you sure?', stopmsg='STOP', callbackdict=None):
         if answer is False:
             print(stopmsg)
             print()
-            exit(0)
+            sys.exit(0)
             return
 
 

--- a/tests/parallel_processing_config.py
+++ b/tests/parallel_processing_config.py
@@ -17,6 +17,9 @@ class processing_cfg(rt1_processing_config):
         super().__init__(**kwargs)
 
     def reader(self, **reader_arg):
+
+        self.check_dump_exists(reader_arg)
+
         # initialize a reader
         if reader_arg['gpi'] in [1,2,3]:
             index = pd.date_range('1.1.2017', '1.1.2018', freq='D')

--- a/tests/parallel_processing_config.py
+++ b/tests/parallel_processing_config.py
@@ -5,7 +5,6 @@ os.environ['MKL_NUM_THREADS'] = '1'
 os.environ['OMP_NUM_THREADS'] = '1'
 os.environ['NUMEXPR_NUM_THREADS'] = '1'
 
-from rt1.rtparse import RT1_configparser
 from rt1.processing_config import rt1_processing_config
 
 import pandas as pd
@@ -14,10 +13,8 @@ import numpy as np
 
 # subclass the configuration and add a reader
 class processing_cfg(rt1_processing_config):
-    def __init__(self, config_path, **kwargs):
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.config_path = config_path
-
 
     def reader(self, **reader_arg):
         # initialize a reader
@@ -31,35 +28,3 @@ class processing_cfg(rt1_processing_config):
             df = pd.DataFrame()
 
         return df
-
-
-    def run_procesing(self, reader_args, ncpu):
-
-        # get fit object by using a config-file
-        config = RT1_configparser(self.config_path)
-        rt1_fits = config.get_fitobject()
-
-        res = rt1_fits.processfunc(ncpu=ncpu,
-                                   reader_args=reader_args,
-                                   lsq_kwargs=None,
-                                   pool_kwargs=None,
-                                   reader=self.reader,
-                                   preprocess=self.preprocess,
-                                   postprocess=self.postprocess,
-                                   exceptfunc=self.exceptfunc,
-                                   finaloutput=self.finaloutput
-                                   )
-
-
-def run(config_path, reader_args, ncpu):
-
-    cfg = RT1_configparser(config_path)
-    spec = cfg.get_process_specs()
-
-    proc = processing_cfg(config_path=config_path,
-                          save_path=spec['save_path'],
-                          dumpfolder=spec['dumpfolder'],
-                          error_dumpfolder=spec['dumpfolder'],
-                          finalout_name=spec['finalout_name'])
-
-    proc.run_procesing(reader_args=reader_args, ncpu=ncpu)

--- a/tests/test_config.ini
+++ b/tests/test_config.ini
@@ -77,13 +77,13 @@ ncoefs   = 10
 
 [CONFIGFILES]
 
-module__processfuncs = tests/parallel_processing_config.py
-copy = ${PROCESS_SPECS:path__save_path}/${PROCESS_SPECS:dumpfolder}/cfg
+module__processing_cfg = tests/parallel_processing_config.py
 
 [PROCESS_SPECS]
 
 finalout_name = results.h5
 dumpfolder = dump01
+error_dumpfolder = ${PROCESS_SPECS:dumpfolder}
 
 path__save_path = tests/proc_test
 

--- a/tests/test_configparser.py
+++ b/tests/test_configparser.py
@@ -135,23 +135,14 @@ class TestCONFIGPARSER(unittest.TestCase):
 
         #----------------------------------------- check imported module
         cfg_module_dict = cfg.get_all_modules()
-        assert 'processfuncs' in cfg_module_dict, 'modules not correctly parsed'
-        cfg_module = cfg_module_dict['processfuncs']
+        assert 'processing_cfg' in cfg_module_dict, 'modules not correctly parsed'
+        cfg_module = cfg_module_dict['processing_cfg']
 
         assert hasattr(cfg_module, 'processing_cfg'), 'modules not correctly parsed'
-        assert hasattr(cfg_module, 'run'), 'modules not correctly parsed'
 
 
-        cfg_module_direct = cfg.get_module('processfuncs')
+        cfg_module_direct = cfg.get_module('processing_cfg')
         assert hasattr(cfg_module_direct, 'processing_cfg'), 'direct-module load not working'
-        assert hasattr(cfg_module_direct, 'run'), 'direct-module load not working'
-
-
-
-        #----------------------------------------- check if files have been copied
-        assert Path('tests/proc_test/dump01/cfg').exists(), 'copying did not work'
-        assert Path('tests/proc_test/dump01/cfg/test_config.ini').exists(), 'copying did not work'
-        assert Path('tests/proc_test/dump01/cfg/parallel_processing_config.py').exists(), 'copying did not work'
 
 
 if __name__ == "__main__":

--- a/tests/test_parallel_processing.py
+++ b/tests/test_parallel_processing.py
@@ -3,24 +3,24 @@ from pathlib import Path
 sys.path.append(str(Path('H:/python_modules/rt_model_python/rt1')))
 import unittest
 from pathlib import Path
-from rt1.rtprocess import RTprocess
+from rt1.rtprocess import RTprocess, RTresults
 import shutil
 
 import warnings
 warnings.simplefilter('ignore')
 
+# use "test_0_---"   "test_1_---"   to ensure test-order
+
 class TestRTfits(unittest.TestCase):
-    def test_parallel_processing(self):
+    def test_0_parallel_processing(self):
         reader_args = [dict(gpi=i) for i in [1, 2, 3, 4]]
         config_path = Path(__file__).parent.absolute() / 'test_config.ini'
 
         proc = RTprocess(config_path, copy=True, autocontinue=True)
 
-        proc.run_processing(ncpu=1, reader_args = reader_args)
+        proc.run_processing(ncpu=4, reader_args = reader_args)
         # run again to check what happens if files already exist
         proc.run_processing(ncpu=4, reader_args = reader_args)
-
-
 
         #----------------------------------------- check if files have been copied
         assert Path('tests/proc_test/dump01/cfg').exists(), 'folder-generation did not work'
@@ -29,25 +29,27 @@ class TestRTfits(unittest.TestCase):
         assert Path('tests/proc_test/dump01/cfg/test_config.ini').exists(), 'copying did not work'
         assert Path('tests/proc_test/dump01/cfg/parallel_processing_config.py').exists(), 'copying did not work'
 
+
+    def test_1_rtresults(self):
+
+        results = RTresults('tests/proc_test')
+        assert hasattr(results, 'dump01'), 'dumpfolder not found by RTresults'
+        fit = results.dump01.load_fit()
+        cfg = results.dump01.load_cfg()
+        dumpfiles = [i for i in results.dump01.dump_files]
 
         # remove the save_path directory
         print('deleting save_path directory...')
         #print('\n'.join([str(i) for i in cfg.get_process_specs()["save_path"].rglob('*')]))
-        shutil.rmtree(proc.dumppath.parent)
+        shutil.rmtree(results._parent_path)
 
 
-
-
-    def test_single_core_processing(self):
+    def test_2_single_core_processing(self):
         reader_args = [dict(gpi=i) for i in [1, 2, 3, 4]]
         config_path = Path(__file__).parent.absolute() / 'test_config.ini'
 
         proc = RTprocess(config_path, copy=True, autocontinue=True)
-
         proc.run_processing(ncpu=1, reader_args = reader_args)
-        # run again to check what happens if files already exist
-        proc.run_processing(ncpu=1, reader_args = reader_args)
-
 
         #----------------------------------------- check if files have been copied
         assert Path('tests/proc_test/dump01/cfg').exists(), 'folder-generation did not work'
@@ -55,8 +57,6 @@ class TestRTfits(unittest.TestCase):
         assert Path('tests/proc_test/dump01/dumps').exists(), 'folder-generation did not work'
         assert Path('tests/proc_test/dump01/cfg/test_config.ini').exists(), 'copying did not work'
         assert Path('tests/proc_test/dump01/cfg/parallel_processing_config.py').exists(), 'copying did not work'
-
-
 
         # remove the save_path directory
         print('deleting save_path directory...')

--- a/tests/test_parallel_processing.py
+++ b/tests/test_parallel_processing.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 sys.path.append(str(Path('H:/python_modules/rt_model_python/rt1')))
 import unittest
+import unittest.mock as mock
 from pathlib import Path
 from rt1.rtprocess import RTprocess, RTresults
 import shutil
@@ -19,6 +20,7 @@ class TestRTfits(unittest.TestCase):
         proc = RTprocess(config_path, copy=True, autocontinue=True)
 
         proc.run_processing(ncpu=4, reader_args = reader_args)
+
         # run again to check what happens if files already exist
         proc.run_processing(ncpu=4, reader_args = reader_args)
 
@@ -34,21 +36,33 @@ class TestRTfits(unittest.TestCase):
 
         results = RTresults('tests/proc_test')
         assert hasattr(results, 'dump01'), 'dumpfolder not found by RTresults'
+
         fit = results.dump01.load_fit()
         cfg = results.dump01.load_cfg()
         dumpfiles = [i for i in results.dump01.dump_files]
 
+        with self.assertRaises(AssertionError):
+            # TODO implement netcdf export and properly test netcdf's !
+            ncfile = results.dump01.load_nc()
+        with self.assertRaises(AssertionError):
+            # TODO implement netcdf export and properly test netcdf's !
+            ncfile = results.dump01.NetCDF_variables
+
         # remove the save_path directory
-        print('deleting save_path directory...')
-        #print('\n'.join([str(i) for i in cfg.get_process_specs()["save_path"].rglob('*')]))
-        shutil.rmtree(results._parent_path)
+        #print('deleting save_path directory...')
+        #shutil.rmtree(results._parent_path)
 
 
     def test_2_single_core_processing(self):
         reader_args = [dict(gpi=i) for i in [1, 2, 3, 4]]
         config_path = Path(__file__).parent.absolute() / 'test_config.ini'
 
-        proc = RTprocess(config_path, copy=True, autocontinue=True)
+        # mock inputs as shown here: https://stackoverflow.com/a/37467870/9703451
+        with mock.patch('builtins.input', side_effect=['REMOVE', 'Y']):
+            proc = RTprocess(config_path, copy=True, autocontinue=False)
+
+        assert len(list(Path('tests/proc_test/dump01/dumps').iterdir())) == 0, 'user-input REMOVE did not work'
+
         proc.run_processing(ncpu=1, reader_args = reader_args)
 
         #----------------------------------------- check if files have been copied
@@ -59,9 +73,8 @@ class TestRTfits(unittest.TestCase):
         assert Path('tests/proc_test/dump01/cfg/parallel_processing_config.py').exists(), 'copying did not work'
 
         # remove the save_path directory
-        print('deleting save_path directory...')
-        #print('\n'.join([str(i) for i in cfg.get_process_specs()["save_path"].rglob('*')]))
-        shutil.rmtree(proc.dumppath.parent)
+        #print('deleting save_path directory...')
+        #shutil.rmtree(proc.dumppath.parent)
 
 
 if __name__ == "__main__":

--- a/tests/test_parallel_processing.py
+++ b/tests/test_parallel_processing.py
@@ -58,6 +58,14 @@ class TestRTfits(unittest.TestCase):
         config_path = Path(__file__).parent.absolute() / 'test_config.ini'
 
         # mock inputs as shown here: https://stackoverflow.com/a/37467870/9703451
+        with self.assertRaises(SystemExit):
+            with mock.patch('builtins.input', side_effect=['N']):
+                proc = RTprocess(config_path, copy=True, autocontinue=False)
+
+        with self.assertRaises(SystemExit):
+            with mock.patch('builtins.input', side_effect=['REMOVE', 'N']):
+                proc = RTprocess(config_path, copy=True, autocontinue=False)
+
         with mock.patch('builtins.input', side_effect=['REMOVE', 'Y']):
             proc = RTprocess(config_path, copy=True, autocontinue=False)
 

--- a/tests/test_parallel_processing.py
+++ b/tests/test_parallel_processing.py
@@ -3,56 +3,45 @@ from pathlib import Path
 sys.path.append(str(Path('H:/python_modules/rt_model_python/rt1')))
 import unittest
 from pathlib import Path
-from rt1.rtparse import RT1_configparser
+from rt1.rtprocess import RTprocess
 import shutil
+
+import warnings
+warnings.simplefilter('ignore')
 
 class TestRTfits(unittest.TestCase):
     def test_parallel_processing(self):
-        ncpu = 4
+        reader_args = [dict(gpi=i) for i in [1, 2, 3, 4]]
         config_path = Path(__file__).parent.absolute() / 'test_config.ini'
 
-        cfg = RT1_configparser(config_path)
-        run = cfg.get_module('processfuncs').run
+        proc = RTprocess(config_path, copy=True, autocontinue=True)
 
-        reader_args = [dict(gpi=i) for i in [1, 2, 3, 4]]
-
-        run(config_path=config_path,
-            reader_args=reader_args,
-            ncpu=ncpu)
-
+        proc.run_processing(ncpu=1, reader_args = reader_args)
         # run again to check what happens if files already exist
-        run(config_path=config_path,
-            reader_args=reader_args,
-            ncpu=ncpu)
+        proc.run_processing(ncpu=4, reader_args = reader_args)
+
 
         # remove the save_path directory
         print('deleting save_path directory...')
         #print('\n'.join([str(i) for i in cfg.get_process_specs()["save_path"].rglob('*')]))
-        shutil.rmtree(cfg.get_process_specs()['save_path'])
+        shutil.rmtree(proc.dumppath.parent)
 
 
     def test_single_core_processing(self):
-        ncpu = 1
+        reader_args = [dict(gpi=i) for i in [1, 2, 3, 4]]
         config_path = Path(__file__).parent.absolute() / 'test_config.ini'
 
-        cfg = RT1_configparser(config_path)
-        run = cfg.get_all_modules()['processfuncs'].run
+        proc = RTprocess(config_path, copy=True, autocontinue=True)
 
-        reader_args = [dict(gpi=i) for i in [1, 2, 3, 4]]
-
-        run(config_path=config_path,
-            reader_args=reader_args,
-            ncpu=ncpu)
-
+        proc.run_processing(ncpu=1, reader_args = reader_args)
         # run again to check what happens if files already exist
-        run(config_path=config_path,
-            reader_args=reader_args,
-            ncpu=ncpu)
+        proc.run_processing(ncpu=1, reader_args = reader_args)
+
 
         # remove the save_path directory
         print('deleting save_path directory...')
         #print('\n'.join([str(i) for i in cfg.get_process_specs()["save_path"].rglob('*')]))
-        shutil.rmtree(cfg.get_process_specs()['save_path'])
+        shutil.rmtree(proc.dumppath.parent)
 
 
 if __name__ == "__main__":

--- a/tests/test_parallel_processing.py
+++ b/tests/test_parallel_processing.py
@@ -21,10 +21,21 @@ class TestRTfits(unittest.TestCase):
         proc.run_processing(ncpu=4, reader_args = reader_args)
 
 
+
+        #----------------------------------------- check if files have been copied
+        assert Path('tests/proc_test/dump01/cfg').exists(), 'folder-generation did not work'
+        assert Path('tests/proc_test/dump01/results').exists(), 'folder-generation did not work'
+        assert Path('tests/proc_test/dump01/dumps').exists(), 'folder-generation did not work'
+        assert Path('tests/proc_test/dump01/cfg/test_config.ini').exists(), 'copying did not work'
+        assert Path('tests/proc_test/dump01/cfg/parallel_processing_config.py').exists(), 'copying did not work'
+
+
         # remove the save_path directory
         print('deleting save_path directory...')
         #print('\n'.join([str(i) for i in cfg.get_process_specs()["save_path"].rglob('*')]))
         shutil.rmtree(proc.dumppath.parent)
+
+
 
 
     def test_single_core_processing(self):
@@ -36,6 +47,15 @@ class TestRTfits(unittest.TestCase):
         proc.run_processing(ncpu=1, reader_args = reader_args)
         # run again to check what happens if files already exist
         proc.run_processing(ncpu=1, reader_args = reader_args)
+
+
+        #----------------------------------------- check if files have been copied
+        assert Path('tests/proc_test/dump01/cfg').exists(), 'folder-generation did not work'
+        assert Path('tests/proc_test/dump01/results').exists(), 'folder-generation did not work'
+        assert Path('tests/proc_test/dump01/dumps').exists(), 'folder-generation did not work'
+        assert Path('tests/proc_test/dump01/cfg/test_config.ini').exists(), 'copying did not work'
+        assert Path('tests/proc_test/dump01/cfg/parallel_processing_config.py').exists(), 'copying did not work'
+
 
 
         # remove the save_path directory

--- a/tests/test_parallel_processing.py
+++ b/tests/test_parallel_processing.py
@@ -17,7 +17,7 @@ class TestRTfits(unittest.TestCase):
         reader_args = [dict(gpi=i) for i in [1, 2, 3, 4]]
         config_path = Path(__file__).parent.absolute() / 'test_config.ini'
 
-        proc = RTprocess(config_path, copy=True, autocontinue=True)
+        proc = RTprocess(config_path, autocontinue=True)
 
         proc.run_processing(ncpu=4, reader_args = reader_args)
 
@@ -60,25 +60,28 @@ class TestRTfits(unittest.TestCase):
         # mock inputs as shown here: https://stackoverflow.com/a/37467870/9703451
         with self.assertRaises(SystemExit):
             with mock.patch('builtins.input', side_effect=['N']):
-                proc = RTprocess(config_path, copy=True, autocontinue=False)
+                proc = RTprocess(config_path, autocontinue=False)
+                proc.setup()
 
         with self.assertRaises(SystemExit):
             with mock.patch('builtins.input', side_effect=['REMOVE', 'N']):
-                proc = RTprocess(config_path, copy=True, autocontinue=False)
+                proc = RTprocess(config_path, autocontinue=False)
+                proc.setup()
 
         with mock.patch('builtins.input', side_effect=['REMOVE', 'Y']):
-            proc = RTprocess(config_path, copy=True, autocontinue=False)
-
+            proc = RTprocess(config_path, autocontinue=False)
+            proc.setup()
         assert len(list(Path('tests/proc_test/dump01/dumps').iterdir())) == 0, 'user-input REMOVE did not work'
 
-        proc.run_processing(ncpu=1, reader_args = reader_args)
+        with mock.patch('builtins.input', side_effect=['REMOVE', 'Y']):
+            proc.run_processing(ncpu=1, reader_args = reader_args, copy=False)
 
         #----------------------------------------- check if files have been copied
         assert Path('tests/proc_test/dump01/cfg').exists(), 'folder-generation did not work'
         assert Path('tests/proc_test/dump01/results').exists(), 'folder-generation did not work'
         assert Path('tests/proc_test/dump01/dumps').exists(), 'folder-generation did not work'
-        assert Path('tests/proc_test/dump01/cfg/test_config.ini').exists(), 'copying did not work'
-        assert Path('tests/proc_test/dump01/cfg/parallel_processing_config.py').exists(), 'copying did not work'
+        assert not Path('tests/proc_test/dump01/cfg/test_config.ini').exists(), 'NOT copying did not work'
+        assert not Path('tests/proc_test/dump01/cfg/parallel_processing_config.py').exists(), 'NOT copying did not work'
 
         # remove the save_path directory
         #print('deleting save_path directory...')


### PR DESCRIPTION
- introduction of new module `rt1.rtprocess`
    - with classes `RTprocess` and `RTresults`
- shift copying of files from `rt1.rtparse` to `rt1.rtprocess.RTprocess.setup()`
- remove `processfunc`, `_evalfunc` etc. from `rt1.rtfits`
- change default file-ending for errors from `.dump`to `.txt`
