### PR TITLE
merge for v1.2

### DIFF
--- a/rt1/__init__.py
+++ b/rt1/__init__.py
@@ -2,5 +2,5 @@
 Import module for RT1 module
 """
 
-__version__ = '1.1.9'
+__version__ = '1.2'
 __author__ = 'Raphael Quast'

--- a/rt1/processing_config.py
+++ b/rt1/processing_config.py
@@ -192,7 +192,7 @@ class rt1_processing_config(object):
         return
 
 
-    def reader(self, **reader_arg):
+    def reader(self, reader_arg):
         '''
         a function that is called for each site to obtain the dataset
         '''

--- a/rt1/rtparse.py
+++ b/rt1/rtparse.py
@@ -225,7 +225,7 @@ class RT1_configparser(object):
                 #assert inp[key].startswith('['), f'{key}  must start with "[" '
                 #assert inp[key].endswith(']'), f'{key} must end with "]" '
                 #val = inp[key][1:-1].replace(' ', '').split(',')
-                if inp[key] == None:
+                if inp[key] == 'None':
                     val = []
                 else:
                     val = inp[key].replace(' ', '').split(',')

--- a/rt1/rtparse.py
+++ b/rt1/rtparse.py
@@ -225,13 +225,17 @@ class RT1_configparser(object):
                 #assert inp[key].startswith('['), f'{key}  must start with "[" '
                 #assert inp[key].endswith(']'), f'{key} must end with "]" '
                 #val = inp[key][1:-1].replace(' ', '').split(',')
-                if inp[key] is None:
+                if inp[key] == None:
                     val = []
                 else:
                     val = inp[key].replace(' ', '').split(',')
                     val = [i for i in val if len(i) > 0]
             else:
-                val = inp[key]
+                # parse None as "real" None
+                if inp[key] == 'None':
+                    val = None
+                else:
+                    val = inp[key]
 
             parsed_dict[key] = val
         return parsed_dict
@@ -432,6 +436,10 @@ class RT1_configparser(object):
 
         process_specs = dict()
         for key, val in inp.items():
+            # parse None as a 'real' None and not as the string 'None'
+            if val == 'None':
+                val = None
+
             if key.startswith('datetime__'):
                 date = dict(zip(['s', 'fmt'],
                         [i.strip() for i in val.split('fmt=')]))

--- a/rt1/rtprocess.py
+++ b/rt1/rtprocess.py
@@ -522,6 +522,13 @@ class RTprocess(object):
                 res = res_async.get()
         else:
             print('start of single-core evaluation')
+
+            # call the initializer if it has been provided
+            if 'initializer' in pool_kwargs:
+                if 'initargs' in pool_kwargs:
+                    pool_kwargs['initializer'](*pool_kwargs['initargs'])
+                else:
+                    pool_kwargs['initializer']()
             res = []
             for reader_arg in reader_args:
                 res.append(self._evalfunc(reader_arg=reader_arg,

--- a/tests/parallel_processing_config.py
+++ b/tests/parallel_processing_config.py
@@ -16,7 +16,7 @@ class processing_cfg(rt1_processing_config):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def reader(self, **reader_arg):
+    def reader(self, reader_arg):
 
         self.check_dump_exists(reader_arg)
 


### PR DESCRIPTION
### changes
- the reader-function in `rt1.rtprocess` is now called without dict-unpacking!!  
  (e.g. via  `reader(reader_args)` instead of `reader(**reader_args)`)  
  this might require adapting existing scripts!
### fixes
- correct parsing of `None` in `rt1.rtparse`
- multiprocessing pool initializer also executed in single core processing (for debug)
- `rt1.rtprocess` now uses `warnings.warn` instead of `print` for general messages
### new
- convenience-method `interpolate_to_index()` added to `rt1.genreal_functions`