### PR TITLE
Multiconfig processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tests/testdump2.dump
 tests/proc_test
 tests/proc_test2
 tests/proc_test3
+tests/proc_multi

--- a/rt1/processing_config.py
+++ b/rt1/processing_config.py
@@ -408,9 +408,6 @@ class rt1_processing_config(object):
         # parse defdict to find static and dynamic parameter names
         params = defdict_parser(fit.defdict)
 
-        # make a dump of the fit
-        self.dump_fit_to_file(fit, reader_arg)
-
         # add all constant (fitted) parameters as static layers
         staticlayers = dict()
         for key in params["fitted_const"]:

--- a/rt1/processing_config.py
+++ b/rt1/processing_config.py
@@ -425,46 +425,19 @@ class rt1_processing_config(object):
 
         return ret
 
-    def finaloutput(self, res, format="table"):
+    def finaloutput(self, res):
         """
         A function that is called after ALL sites are processed:
-
-        First, the obtained parameter-dataframes returned by the
-        `postprocess()` function are concatenated, then:
-
-            - if `"save_path"` is defined, the resulting dataframe will be
-              saved (or appended) to a hdf-store.
-              the used key will be either the value of `"hdf_key"` or
-              `"dumpfolder`" or in case both are `None`, the key `"result`"
-              will be used
-            - if `"save_path"` is None, the DataFrame of the concatenated
-              results will be returned
-
-        Notice:
-        Since hdf is a row-based format, the HDF-file will contain a transposed
-        version of the multiindexed "res"-DataFrame.
-        Furthermore all values will be converted to numerical values
-        by using `pd.to_numeric()`   -> timestaps need to be re-converted using
-        `pd.to_datetime()`!
-
 
         Parameters
         ----------
         res: list
             A list of return-values from the "postprocess()" function.
-        save_path: str, optional
-            The path where the finalout-file will be stored.
-            The default is None.
-        format: str
-            the format used when exporting the hdf-file.
 
-            Notice: if there are more than 2000 entries, the 'table' format
-            will not work and the 'fixed' format must be used!
-            The default is 'fixed'
         Returns
         -------
-        res: pandas.DataFrame
-             the concatenated results (ONLY if `"save_path"` is `None`)
+        res: xarray.Dataset
+             the concatenated results
         """
 
         # concatenate the results

--- a/rt1/rtprocess.py
+++ b/rt1/rtprocess.py
@@ -188,7 +188,6 @@ class RTprocess(object):
         proc_cls=None,
         parent_fit=None,
         init_kwargs=None,
-        setup=True,
     ):
         """
         A class to perform parallelized processing.

--- a/rt1/rtprocess.py
+++ b/rt1/rtprocess.py
@@ -229,16 +229,6 @@ class RTprocess(object):
             Additional keyword-arguments passed to the initialization of the
             'proc_cls' class. (used to append-to or partially overwrite
             definitions passed via the config-file). The default is None.
-        setup : bool, optional
-            indicator if `RTprocess.setup()` should be called during
-            initialization or not. This is required for multiprocessing
-            on Windows since `setup()` needs to be called outside of the
-            `if __name__ == '__main__'` protector to ensure correct import
-            of the used processing_config class.
-            Notice that if setup is set to True (the default) the
-            folder-structure etc. will be initialized as soon as the
-            class object is created!
-            The default is True.
         """
 
         self.config_path = config_path
@@ -258,9 +248,6 @@ class RTprocess(object):
                 [isinstance(i, str) for i in init_kwargs.values()]
             ), 'the values of "init_kwargs" MUST be strings !'
             self.init_kwargs = init_kwargs
-
-        if setup:
-            self.setup()
 
     def _listener_process(self, queue):
 
@@ -590,9 +577,9 @@ class RTprocess(object):
         (>> returns from provided initializer are returned)
         """
 
-        # preload ALL modules to ensure that the importer finds them at the
-        # desired locations (e.g. the cfg-folders)
-        _ = self.cfg.get_all_modules(load_copy=self.copy)
+        # call setup() on each worker-process to ensure that the importer loads
+        # all required modules from the desired locations
+        self.setup()
 
         if queue is not None:
             self._worker_configurer(queue)

--- a/rt1/rtprocess.py
+++ b/rt1/rtprocess.py
@@ -1,7 +1,7 @@
 import multiprocessing as mp
 from timeit import default_timer
 from datetime import datetime, timedelta
-from itertools import repeat, islice
+from itertools import repeat, islice, zip_longest
 from functools import partial
 import ctypes
 import sys
@@ -229,8 +229,13 @@ class RTprocess(object):
             'proc_cls' class. (used to append-to or partially overwrite
             definitions passed via the config-file). The default is None.
         """
+        assert config_path is not None, "Please provide a config-path!"
+        self.config_path = Path(config_path)
 
-        self.config_path = config_path
+        assert self.config_path.exists(), (
+            f"the file {self.config_path} " + "does not exist!"
+        )
+
         self.autocontinue = autocontinue
 
         self._postprocess = True
@@ -325,11 +330,32 @@ class RTprocess(object):
                 str(key): str(val) for key, val in init_defs.items()
             }
 
-        if override is True:
-            self.init_kwargs = init_kwargs
-        else:
-            for section, init_defs in self.init_kwargs.items():
-                init_defs.update(init_kwargs[section])
+        if override is False:
+            for section, init_defs in init_kwargs.items():
+                init_kwargs[section] = {
+                    **self.init_kwargs.get(section, {}),
+                    **init_defs,
+                }
+
+        self.init_kwargs = init_kwargs
+
+    def _remove_dumpfolder(self):
+        # try to close existing filehandlers to avoid
+        # errors if the files are located in the folder
+        # if they are actually in the cfg folder, delete
+        # the corresponding handler as well!
+        for h in log.handlers:
+            try:
+                h.close()
+                if Path(h.baseFilename).parent.samefile(self.dumppath / "cfg"):
+                    log.removeHandler(h)
+            except Exception:
+                pass
+
+        # remove folderstructure
+        shutil.rmtree(self.dumppath)
+
+        log.info(f'"{self.dumppath}"' + "\nhas successfully been removed.\n")
 
     def setup(self):
         """
@@ -339,109 +365,86 @@ class RTprocess(object):
           - load modules and set parent-fit-object
         """
 
-        if self.config_path is not None and self._proc_cls is None:
+        self.cfg = RT1_configparser(self.config_path)
 
-            self.config_path = Path(self.config_path)
-            assert self.config_path.exists(), (
-                f"the file {self.config_path} " + "does not exist!"
+        # update specs with init_kwargs
+        for section, init_defs in self.init_kwargs.items():
+            assert (
+                section in self.cfg.config
+            ), f"the init_kwargs section {section} is not present in the .ini file!"
+
+            for key, val in init_defs.items():
+                if key in self.cfg.config[section]:
+                    log.warning(
+                        f'"{key} = {self.cfg.config[section][key]}" '
+                        + "will be overwritten by the definition provided via "
+                        + f'"init_kwargs[{section}]": "{key} = {val}" '
+                    )
+                    # update the parsed config (for import of modules etc.)
+                    self.cfg.config[section][key] = val
+
+        specs = self.cfg.get_process_specs()
+        self.dumppath = specs["save_path"] / specs["dumpfolder"]
+
+        if mp.current_process().name == "MainProcess":
+            # init folderstructure and copy files only from main process
+            if self.autocontinue is False:
+
+                if self.dumppath.exists():
+                    _confirm_input(
+                        msg=(
+                            f'the path \n "{self.dumppath}"\n'
+                            + " already exists..."
+                            + "\n- to continue type YES or Y"
+                            + "\n- to abort type NO or N"
+                            + "\n- to remove the existing directory and "
+                            + "all subdirectories type REMOVE \n \n"
+                        ),
+                        stopmsg='aborting due to manual input "NO"',
+                        callbackdict={
+                            "REMOVE": [
+                                (
+                                    f'\n"{self.dumppath}"\n will be removed!'
+                                    + " are you sure? (y, n): "
+                                ),
+                                self._remove_dumpfolder,
+                            ]
+                        },
+                    )
+
+            # initialize the folderstructure
+            _make_folderstructure(
+                specs["save_path"] / specs["dumpfolder"],
+                ["results", "cfg", "dumps"],
             )
 
-            self.cfg = RT1_configparser(self.config_path)
-
-            # update specs with init_kwargs
-            # remember warnings and log them later in case dumppath is changed
-            for section, init_defs in self.init_kwargs.items():
-                assert (
-                    section in self.cfg.config
-                ), f"the init_kwargs section {section} is not present in the .ini file!"
-
-                for key, val in init_defs.items():
-                    if key in self.cfg.config[section]:
-                        log.warning(
-                            f'"{key} = {self.cfg.config[section][key]}" '
-                            + "will be overwritten by the definition provided via "
-                            + f'"init_kwargs[{section}]": "{key} = {val}" '
-                        )
-                        # update the parsed config (for import of modules etc.)
-                        self.cfg.config[section][key] = val
-
-            specs = self.cfg.get_process_specs()
-
-            self.dumppath = specs["save_path"] / specs["dumpfolder"]
-
-            if mp.current_process().name == "MainProcess":
-                # init folderstructure and copy files only from main process
-                if self.autocontinue is False:
-
-                    if self.dumppath.exists():
-
-                        def remove_folder():
-
-                            # try to close existing filehandlers to avoid
-                            # errors if the files are located in the folder
-                            # if they are actually in the cfg folder, delete
-                            # the corresponding handler as well!
-                            for h in log.handlers:
-                                try:
-                                    h.close()
-                                    if Path(h.baseFilename).parent.samefile(
-                                        self.dumppath / "cfg"
-                                    ):
-                                        log.removeHandler(h)
-                                except Exception:
-                                    pass
-
-                            # remove folderstructure
-                            shutil.rmtree(self.dumppath)
-
-                            log.info(
-                                f'"{self.dumppath}"'
-                                + "\nhas successfully been removed.\n"
-                            )
-
-                        _confirm_input(
-                            msg=(
-                                f'the path \n "{self.dumppath}"\n'
-                                + " already exists..."
-                                + "\n- to continue type YES or Y"
-                                + "\n- to abort type NO or N"
-                                + "\n- to remove the existing directory and "
-                                + "all subdirectories type REMOVE \n \n"
-                            ),
-                            stopmsg='aborting due to manual input "NO"',
-                            callbackdict={
-                                "REMOVE": [
-                                    (
-                                        f'\n"{self.dumppath}"\n will be removed!'
-                                        + " are you sure? (y, n): "
-                                    ),
-                                    remove_folder,
-                                ]
-                            },
-                        )
-
-                # initialize the folderstructure
+            # in case multiple configurations are provided, initialize subfolders
+            # in the "dumps" and "results" directories
+            if len(self.cfg.config_names) > 0:
                 _make_folderstructure(
-                    specs["save_path"] / specs["dumpfolder"],
-                    ["results", "cfg", "dumps"],
+                    specs["save_path"] / specs["dumpfolder"] / "dumps",
+                    self.cfg.config_names,
+                )
+                _make_folderstructure(
+                    specs["save_path"] / specs["dumpfolder"] / "results",
+                    self.cfg.config_names,
                 )
 
-                if self.copy is True:
-                    self._copy_cfg_and_modules()
+        # copy modules and config-files and ensure that they are loaded from the
+        # right direction (NO files will be overwritten!!)
+        if self.copy is True:
+            self._copy_cfg_and_modules()
 
-            # load the processing-class
-            if "processing_cfg_module" in specs:
-                proc_module_name = specs["processing_cfg_module"]
-            else:
-                proc_module_name = "processing_cfg"
+        # get the name of the processing-module and the processing-class
+        proc_module_name = specs.get("processing_cfg_module", "processing_cfg")
+        proc_class_name = specs.get("processing_cfg_class", "processing_cfg")
 
-            if "processing_cfg_class" in specs:
-                proc_class_name = specs["processing_cfg_class"]
-            else:
-                proc_class_name = "processing_cfg"
+        # load ALL modules to ensure that the importer finds them
+        procmodule = self.cfg.get_all_modules(load_copy=self.copy)[proc_module_name]
 
-            # load ALL modules to ensure that the importer finds them
-            procmodule = self.cfg.get_all_modules(load_copy=self.copy)[proc_module_name]
+        # only import proc_cls if it is not yet set
+        # (to allow overriding already set properties during runtime)
+        if self._proc_cls is None:
 
             log.debug(
                 f'processing config class "{proc_class_name}"'
@@ -449,14 +452,14 @@ class RTprocess(object):
             )
 
             self.proc_cls = getattr(procmodule, proc_class_name)(**specs)
-
-            # get the parent fit-object
-            if self._parent_fit is None:
-                self.parent_fit = self.cfg.get_fitobject()
-            else:
-                self.parent_fit = self._parent_fit
         else:
-            self.dumppath = None
+            self.proc_cls = self._proc_cls
+
+        # get the parent fit-object
+        if self._parent_fit is None:
+            self.parent_fit = self.cfg.get_fitobject()
+        else:
+            self.parent_fit = self._parent_fit
 
         # check if all necessary functions are defined in the  processing-class
         for key in [
@@ -478,9 +481,9 @@ class RTprocess(object):
         # if copy is True, copy the config-file and re-import the cfg
         # from the copied file
         copypath = self.dumppath / "cfg" / self.cfg.configpath.name
-        if (copypath).exists():
+        if (copypath).exists() and len(self.init_kwargs) == 0:
             log.warning(
-                f'the file \n"{copypath / self.cfg.configpath.name}"\n'
+                f'the file \n"{copypath}"\n'
                 + "already exists... NO copying is performed and the "
                 + "existing one is used!\n"
             )
@@ -495,18 +498,18 @@ class RTprocess(object):
             else:
                 # if init_kwargs have been provided, write the updated
                 # config to the folder
-                with open(copypath.parent / self.cfg.configpath.name, "w") as file:
+                with open(copypath, "w") as file:
                     self.cfg.config.write(file)
 
-                log.info(
+                log.warning(
                     f'the config-file "{self.cfg.configpath}" has been'
                     + " updated with the init_kwargs and saved to"
-                    + f'"{copypath.parent / self.cfg.configpath.name}"'
+                    + f'"{copypath}"'
                 )
 
-            # remove the config and re-read the config from the copied path
-            del self.cfg
-            self.cfg = RT1_configparser(copypath)
+        # remove the config and re-read the config from the copied path
+        del self.cfg
+        self.cfg = RT1_configparser(copypath)
 
         # copy modules
         for key, val in self.cfg.config["CONFIGFILES"].items():
@@ -570,32 +573,67 @@ class RTprocess(object):
                     + "must be a pandas DataFrame"
                 )
             # initialize a new fits-object and perform the fit
-            fit = self.parent_fit.reinit_object(dataset=dataset)
-            fit.performfit()
+            if len(self.cfg.config_names) > 0:
+                # in case multiple configs are provided, evaluate them one by one
+                ret = []
+                for cfg_name, parent_fit in self.parent_fit:
 
-            # append auxiliary data
-            if aux_data is not None:
-                fit.aux_data = aux_data
+                    if self.dumppath is not None:
+                        self.proc_cls.rt1_procsesing_dumppath = (
+                            self.dumppath / "dumps" / cfg_name
+                        )
 
-            # append reader_arg
-            fit.reader_arg = reader_arg
+                    fit = parent_fit.reinit_object(dataset=dataset)
+                    fit.performfit()
 
-            if process_cnt is not None:
-                _increase_cnt(process_cnt, start, err=False)
+                    # append auxiliary data
+                    if aux_data is not None:
+                        fit.aux_data = aux_data
+                    # append reader_arg
+                    fit.reader_arg = reader_arg
 
-            # if a post-processing function is provided, return its output,
-            # else return None
-            if self._postprocess and callable(self.proc_cls.postprocess):
-                ret = self.proc_cls.postprocess(fit, reader_arg)
+                    # if a post-processing function is provided, return its output,
+                    # else return None
+                    if self._postprocess and callable(self.proc_cls.postprocess):
+                        ret.append(self.proc_cls.postprocess(fit, reader_arg))
+                    else:
+                        ret.append(None)
+
+                    # dump a fit-file
+                    # save dumps AFTER prostprocessing has been performed
+                    # (it might happen that some parts change during postprocessing)
+                    if self._dump_fit and hasattr(self.proc_cls, "dump_fit_to_file"):
+                        self.proc_cls.dump_fit_to_file(fit, reader_arg, mini=True)
+
+                if process_cnt is not None:
+                    _increase_cnt(process_cnt, start, err=False)
+
             else:
-                ret = None
+                fit = self.parent_fit.reinit_object(dataset=dataset)
+                fit.performfit()
 
-            # dump a fit-file
-            # save dumps AFTER prostprocessing has been performed
-            # (it might happen that some parts change during postprocessing)
-            if self._dump_fit and hasattr(self.proc_cls, "dump_fit_to_file"):
-                self.proc_cls.dump_fit_to_file(fit, reader_arg, mini=True)
+                # append auxiliary data
+                if aux_data is not None:
+                    fit.aux_data = aux_data
 
+                # append reader_arg
+                fit.reader_arg = reader_arg
+
+                if process_cnt is not None:
+                    _increase_cnt(process_cnt, start, err=False)
+
+                # if a post-processing function is provided, return its output,
+                # else return None
+                if self._postprocess and callable(self.proc_cls.postprocess):
+                    ret = self.proc_cls.postprocess(fit, reader_arg)
+                else:
+                    ret = None
+
+                # dump a fit-file
+                # save dumps AFTER prostprocessing has been performed
+                # (it might happen that some parts change during postprocessing)
+                if self._dump_fit and hasattr(self.proc_cls, "dump_fit_to_file"):
+                    self.proc_cls.dump_fit_to_file(fit, reader_arg, mini=True)
             return ret
 
         except Exception as ex:
@@ -763,9 +801,14 @@ class RTprocess(object):
         ]
         pool_kwargs["initializer"] = self._initializer
 
-        if self.parent_fit.int_Q is True:
-            # pre-evaluate the fn-coefficients if interaction terms are used
-            self.parent_fit._fnevals_input = self.parent_fit.R._fnevals
+        # pre-evaluate the fn-coefficients if interaction terms are used
+        if len(self.cfg.config_names) > 0:
+            for i, [cfg_name, parent_fit] in enumerate(self.parent_fit):
+                if parent_fit.int_Q is True:
+                    parent_fit._fnevals_input = parent_fit.R._fnevals
+        else:
+            if self.parent_fit.int_Q is True:
+                self.parent_fit._fnevals_input = self.parent_fit.R._fnevals
 
         if print_progress is True:
             # initialize shared values that will be used to track the number
@@ -787,6 +830,10 @@ class RTprocess(object):
                 res = res_async.get()
         else:
             log.info("start of single-core evaluation")
+            # force autocontinue=True when calling the initializer since setup() has
+            # already been called in the main process so all folders will already exist!
+            init_autocontinue = self.autocontinue
+            self.autocontinue = True
 
             # call the initializer if it has been provided
             if "initializer" in pool_kwargs:
@@ -794,14 +841,25 @@ class RTprocess(object):
                     pool_kwargs["initializer"](*pool_kwargs["initargs"])
                 else:
                     pool_kwargs["initializer"]()
+
+            self.autocontinue = init_autocontinue
+
             res = []
             for reader_arg in reader_args:
                 res.append(
                     self._evalfunc(reader_arg=reader_arg, process_cnt=process_cnt)
                 )
-
+        # call finaloutput if post-processing has been performed and a finaloutput
+        # function is provided
         if self._postprocess and callable(self.proc_cls.finaloutput):
-            return self.proc_cls.finaloutput(res)
+            if len(self.cfg.config_names) > 0:
+                for i, res_i in enumerate(zip_longest(*res)):
+                    self.proc_cls.rt1_procsesing_respath = (
+                        self.dumppath / "results" / self.parent_fit[i][0]
+                    )
+                    self.proc_cls.finaloutput(res_i)
+            else:
+                return self.proc_cls.finaloutput(res)
         else:
             return res
 
@@ -901,19 +959,42 @@ class RTprocess(object):
 
             # save the used model-definition string to a file
             if self.dumppath is not None:
-                with open(self.dumppath / "cfg" / "model_definition.txt", "w") as file:
 
-                    outtxt = ""
-                    if hasattr(self.proc_cls, "description"):
-                        outtxt += dedent(self.proc_cls.description)
-                        outtxt += "\n\n"
-                        outtxt += "_" * 77
-                        outtxt += "\n\n"
+                if len(self.cfg.config_names) > 0:
+                    # if multiple configs are provided, save an individual file for each
+                    for cfg_name, parent_fit in self.parent_fit:
+                        with open(
+                            self.dumppath / "cfg" / f"model_definition__{cfg_name}.txt",
+                            "w",
+                        ) as file:
 
-                    outtxt += self.parent_fit._model_definition
-                    print(outtxt, file=file)
+                            outtxt = ""
+                            if hasattr(self.proc_cls, "description"):
+                                outtxt += dedent(self.proc_cls.description)
+                                outtxt += "\n\n"
+                                outtxt += "_" * 77
+                                outtxt += "\n\n"
 
-                    log.info(outtxt)
+                            outtxt += parent_fit._model_definition
+                            print(outtxt, file=file)
+
+                            log.info(outtxt)
+                else:
+                    with open(
+                        self.dumppath / "cfg" / "model_definition.txt", "w"
+                    ) as file:
+
+                        outtxt = ""
+                        if hasattr(self.proc_cls, "description"):
+                            outtxt += dedent(self.proc_cls.description)
+                            outtxt += "\n\n"
+                            outtxt += "_" * 77
+                            outtxt += "\n\n"
+
+                        outtxt += self.parent_fit._model_definition
+                        print(outtxt, file=file)
+
+                        log.info(outtxt)
 
             _ = self.processfunc(
                 ncpu=ncpu,
@@ -1022,6 +1103,15 @@ class RTprocess(object):
             else:
                 queue = None
 
+            # override finalout_name
+            # do this BEFORE self.setup() is called !!
+            if finalout_name is not None:
+                assert isinstance(finalout_name, str), "finalout_name must be a string"
+                # self.proc_cls.finalout_name = finalout_name
+                self.override_config(
+                    PROCESS_SPECS=dict(finalout_name=finalout_name), override=False
+                )
+
             # initialize all necessary properties with autocontinue=True
             initial_autocontinue = self.autocontinue
             self.autocontinue = True
@@ -1033,16 +1123,35 @@ class RTprocess(object):
                 # otherwise the folder-structure does not yet exist and the
                 # file to which the process is writing can not be generated!
                 listener.start()
+            if len(self.cfg.config_names) > 0:
+                for config_name in self.cfg.config_names:
+                    self.proc_cls.rt1_procsesing_respath = (
+                        self.dumppath / "results" / config_name
+                    )
 
-            return self._run_finalout(
-                ncpu,
-                use_N_files=use_N_files,
-                finalout_name=finalout_name,
-                finaloutput=finaloutput,
-                postprocess=postprocess,
-                queue=queue,
-                print_progress=print_progress,
-            )
+                    fitlist = self._get_files(
+                        use_N_files=use_N_files, use_config=config_name
+                    )
+
+                    self._run_finalout(
+                        ncpu,
+                        fitlist=fitlist,
+                        finaloutput=finaloutput,
+                        postprocess=postprocess,
+                        queue=queue,
+                        print_progress=print_progress,
+                    )
+            else:
+                fitlist = self._get_files(use_N_files=use_N_files)
+
+                return self._run_finalout(
+                    ncpu,
+                    fitlist=fitlist,
+                    finaloutput=finaloutput,
+                    postprocess=postprocess,
+                    queue=queue,
+                    print_progress=print_progress,
+                )
 
         except Exception as err:
             log.exception("there was an error during finalout generation!")
@@ -1070,7 +1179,7 @@ class RTprocess(object):
                     # remove the file-handler from the log
                     log.handlers.remove(h)
 
-    def _run_postprocess(self, fitpath, process_cnt=None):
+    def _run_postprocess(self, fitpath, process_cnt=None, postprocess=None):
         if process_cnt is not None:
             start = _start_cnt()
 
@@ -1083,7 +1192,10 @@ class RTprocess(object):
 
         try:
             # run postprocessing
-            ret = self.proc_cls.postprocess(fit, fit.reader_arg)
+            if postprocess is None:
+                ret = self.proc_cls.postprocess(fit, fit.reader_arg)
+            else:
+                ret = postprocess(fit, fit.reader_arg)
 
             if process_cnt is not None:
                 _increase_cnt(process_cnt, start, err=False)
@@ -1101,34 +1213,17 @@ class RTprocess(object):
             else:
                 raise ex
 
-    def _run_finalout(
-        self,
-        ncpu,
-        use_N_files=None,
-        finalout_name=None,
-        finaloutput=None,
-        postprocess=None,
-        queue=None,
-        print_progress=True,
-    ):
-
-        # override finalout_name
-        if finalout_name is not None:
-            assert isinstance(finalout_name, str), "finalout_name must be a string"
-            self.proc_cls.finalout_name = finalout_name
-
-        # override finaloutput function
-        if finaloutput is not None:
-            assert callable(finaloutput), "finaloutput must be callable!"
-            self.proc_cls.finaloutput = partial(finaloutput, self.proc_cls)
-        # override postprocess function
-        if postprocess is not None:
-            assert callable(postprocess), "postprocess must be callable!"
-            self.proc_cls.postprocess = partial(postprocess, self.proc_cls)
+    def _get_files(self, use_N_files=None, use_config=None):
+        # get the relevant files that have to be processed for `run_finaloutput`
 
         # initialize RTresults class
-        useres = getattr(RTresults(self.dumppath), self.proc_cls.dumpfolder)
-
+        if use_config is None:
+            useres = getattr(RTresults(self.dumppath), self.proc_cls.dumpfolder)
+        else:
+            useres = getattr(
+                RTresults(self.dumppath),
+                f"{self.proc_cls.dumpfolder}__{use_config}",
+            )
         # get dump-files
         dumpiter = useres.dump_files
 
@@ -1136,6 +1231,21 @@ class RTprocess(object):
             fitlist = list(islice(dumpiter, use_N_files))
         else:
             fitlist = list(dumpiter)
+        return fitlist
+
+    def _run_finalout(
+        self,
+        ncpu,
+        fitlist=None,
+        finaloutput=None,
+        postprocess=None,
+        queue=None,
+        print_progress=True,
+    ):
+
+        # override postprocess function
+        if postprocess is not None:
+            assert callable(postprocess), "postprocess must be callable!"
 
         # add provided initializer and queue (used for subprocess-logging)
         # to the initargs and use "self._initializer" as initializer-function
@@ -1154,7 +1264,12 @@ class RTprocess(object):
             with mp.Pool(ncpu, **pool_kwargs) as pool:
                 # loop over the reader_args
                 res_async = pool.starmap_async(
-                    self._run_postprocess, zip(fitlist, repeat(process_cnt))
+                    self._run_postprocess,
+                    zip(
+                        fitlist,
+                        repeat(process_cnt),
+                        repeat(postprocess),
+                    ),
                 )
 
                 pool.close()  # Marks the pool as closed.
@@ -1162,6 +1277,10 @@ class RTprocess(object):
                 res = res_async.get()
         else:
             log.info("start of single-core finalout generation")
+            # force autocontinue=True when calling the initializer since setup() has
+            # already been called in the main process so all folders will already exist!
+            init_autocontinue = self.autocontinue
+            self.autocontinue = True
 
             # call the initializer if it has been provided
             if "initializer" in pool_kwargs:
@@ -1169,15 +1288,23 @@ class RTprocess(object):
                     pool_kwargs["initializer"](*pool_kwargs["initargs"])
                 else:
                     pool_kwargs["initializer"]()
+
+            self.autocontinue = init_autocontinue
             res = []
             for fitpath in fitlist:
                 res.append(
-                    self._run_postprocess(fitpath=fitpath, process_cnt=process_cnt)
+                    self._run_postprocess(
+                        fitpath=fitpath,
+                        process_cnt=process_cnt,
+                        postprocess=postprocess,
+                    )
                 )
 
-        if callable(self.proc_cls.finaloutput):
-            return self.proc_cls.finaloutput(res)
+        if callable(finaloutput):
+            return finaloutput(res)
             log.info("finished generation of finaloutput!")
+        elif hasattr(self.proc_cls, "finaloutput"):
+            return self.proc_cls.finaloutput(res)
         else:
             return res
 
@@ -1189,6 +1316,8 @@ class RTresults(object):
     and recognize any sub-folder that matches the expected folder-structure
     as a sub-result.
 
+    NOTE: only the first 100 entries of each directory will be checked
+    to avoid performance issues in case a folder with a lot of sub-files is selected
 
     Assuming a folder-structure as indicated below, the class can be used via:
 
@@ -1202,8 +1331,14 @@ class RTresults(object):
         ...         dumps/..   (.dump files)
         ...         cfg/..     (.ini files)
         ...
-        ...     sub_RESULT2
-        ...         ....
+        ...     sub_RESULT2_with_multiple_configs
+        ...         results/.. (.nc files)
+        ...             config1/.. (.nc files)
+        ...             config2/.. (.nc files)
+        ...         dumps/..
+        ...             config1/.. (.dump files)
+        ...             config2/.. (.dump files)
+        ...         cfg/..     (.ini files)
 
 
         >>> results = RT1_results(parent_path)
@@ -1238,36 +1373,69 @@ class RTresults(object):
         self._parent_path = Path(parent_path)
 
         self._paths = dict()
+        if self._check_folderstructure(self._parent_path):
+            # check if the path is already a valid folder-structure
+            self._addresult(Path(self._parent_path))
+        else:
+            # otherwise, check if a subfolder has a valid folder-structure
+            # (only 1 level is checked)
+            for p in islice(os.scandir(self._parent_path), 100):
+                if p.is_dir():
+                    self._addresult(Path(p.path))
 
-        if all(
-            i in [i.stem for i in self._parent_path.iterdir()]
-            for i in ["cfg", "results", "dumps"]
-        ):
-            self._paths[self._parent_path.stem] = self._parent_path
-            log.info(f"... adding result {self._parent_path.stem}")
-            setattr(
-                self,
-                self._parent_path.stem,
-                self._RT1_fitresult(self._parent_path.stem, self._parent_path),
-            )
+    @staticmethod
+    def _check_folderstructure(path):
+        return all(
+            folder in [i.name for i in islice(os.scandir(path), 100) if i.is_dir()]
+            for folder in [
+                "cfg",
+                "results",
+                "dumps",
+            ]
+        )
 
-        for p in self._parent_path.iterdir():
-            if p.is_dir():
-                if all(
-                    i in [i.stem for i in p.iterdir()]
-                    for i in ["cfg", "results", "dumps"]
-                ):
-                    self._paths[p.stem] = p
-                    log.info(f"... adding result {p.stem}")
-                    setattr(self, p.stem, self._RT1_fitresult(p.stem, p))
+    def _addresult(self, path):
+        # use os.scandir since it is a lot faster than any other method right now
+        if self._check_folderstructure(path):
+            # check the first 1000 files for subdirectories
+            # avoid checking more for performance reasons
+            subresults = [
+                Path(i.path)
+                for i in islice(os.scandir(path / "dumps"), 100)
+                if i.is_dir()
+            ]
+
+            if len(subresults) > 0:
+                for subres in subresults:
+                    self._paths[path.stem + f"__{subres.stem}"] = path
+                    log.info(f"... adding conifg-result {path.stem}__{subres.stem}")
+                    setattr(
+                        self,
+                        path.stem + f"__{subres.stem}",
+                        self._RT1_fitresult(path.stem, path, subres.stem),
+                    )
+
+            else:
+                self._paths[path.stem] = path
+                log.info(f"... adding result {path.stem}")
+                setattr(
+                    self,
+                    path.stem,
+                    self._RT1_fitresult(path.stem, path),
+                )
 
     class _RT1_fitresult(object):
-        def __init__(self, name, path):
+        def __init__(self, name, path, use_config=None):
             self.name = name
             self.path = Path(path)
-            self._result_path = self.path / "results"
-            self._dump_path = self.path / "dumps"
-            self._cfg_path = self.path / "cfg"
+            if use_config is None:
+                self._result_path = self.path / "results"
+                self._dump_path = self.path / "dumps"
+                self._cfg_path = self.path / "cfg"
+            else:
+                self._result_path = self.path / "results" / use_config
+                self._dump_path = self.path / "dumps" / use_config
+                self._cfg_path = self.path / "cfg"
 
             self._nc_paths = self._get_results(".nc")
 

--- a/tests/test_config_multi.ini
+++ b/tests/test_config_multi.ini
@@ -1,0 +1,122 @@
+###############################################################################
+# GENERAL SPECIFICATIONS
+###############################################################################
+[fits_kwargs]
+# set dataset-properties (e.g. if the input-dataset is in dB or not)
+sig0     = True
+dB       = False
+# define how the index of the results should be set (first, last or mean)
+setindex = first
+# indicator if interaction term should be evaluated
+int_Q          = True
+# backend to use for symbolic evaluation of the interaction term functions
+lambda_backend = symengine
+interp_vals     =   tau,   omega
+_fnevals_input
+# the verbosity (e.g. the level of print outputs)
+verbose = 1
+
+[least_squares_kwargs]
+# keyword-arguments passed to scipy.optimize.least_squares
+# level of print-output
+verbose   = 0
+# termination tolerances
+ftol      = 1.e-4
+gtol      = 1.e-4
+xtol      = 1.e-4
+# maximum number of function evaluations
+max_nfev  = 20
+# used minimization algorithm (trf or dogbox)
+method    = trf
+# method for solving the trust-regions (lsmr or exact)
+tr_solver = lsmr
+# characteristic scale of each variable (jac = use inverse norm of jacobian )
+x_scale   = jac
+
+###############################################################################
+# RT1 MODEL SPECIFICATIONS
+###############################################################################
+[defdict]
+# provide specifications in the following order:
+# parameter = [fitQ, startval, frequency, min, max]
+# fitQ     ... indicator if the parameter should be fitted or not
+# startval ... the start-value to use if the parameter is fitted or the
+#              constant value to use in case it is not fitted
+# freqency ... the variability of the parameters specified as pandas dateoffset
+#              https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#dateoffset-objects
+# min/max  ... the boundary-values used in case the parameter is fitted
+
+omega = [True, 0.05, 2M,    0.01, 0.5, True]
+t_s   = [True, 0.25, None,  0.01, 0.5, False]
+N     = [True, 0.1,  index, 0.01, 0.2]
+tau   = [True, 0.5,  3M,    0.01, 1.5, True]
+tau_multip = [False, 0.5]
+bsf   = [True, 0.05, A,     0.01, 1.]
+
+
+
+
+[RT1_V]
+# the name of the volume-scattering function used (provided in rt1.volume)
+V_name = HenyeyGreenstein
+# parameter assignments
+# ints and floats will be used as constants, strings will be converted
+# to sympy expressions whose free-variables must be set in defdict.
+tau    = tau * tau_multip
+omega  = omega
+t      = t_v
+ncoefs = 10
+
+
+[RT1_SRF]
+# similar as RT1_V but this time the functions of rt1.surface will be used
+SRF_name = HG_nadirnorm
+NormBRDF = N
+t        = t_s
+ncoefs   = 10
+
+
+[CONFIGFILES]
+
+module__processing_cfg = tests/parallel_processing_config.py
+
+[PROCESS_SPECS]
+
+finalout_name = results.nc
+dumpfolder = dump01
+error_dumpfolder = ${PROCESS_SPECS:dumpfolder}
+
+path__save_path = tests/proc_multi
+
+
+# add some additional values
+float__f0 = 1245
+float__f1 = 5.4
+int__i0 = 1
+int__i1 = 5
+bool__b0 = False
+bool__b1 = True
+
+datetime__d0 = 23.3.2020 fmt=%d.%m.%Y
+datetime__d1 = 22-1-17 12:34 fmt= %d-%m-%y %H:%M
+
+
+list__float__lf = [.1  ,.2,  .3,.4,.5]
+list__int__li = [1,  2,3,4,  5  ]
+list__bool__lb = [True, False, 1, 0]
+list__ls = [a,B  ,  c, AbCd#  ]
+list__datetime__ldt = [22-1-17 12:34, 24-3-19 11:13]   fmt= %d-%m-%y %H:%M
+
+
+# ---------- add some tests for MULTI configs
+[#config cfg_0 defdict]
+omega = [False, .5]
+t_v   = [True, 0.25, None,  0.01, 0.5]
+[#config cfg_0 fits_kwargs]
+int_Q = False
+
+
+[#config cfg_1 RT1_V]
+t      = .25
+[#config cfg_1 RT1_SRF]
+ncoefs = 5

--- a/tests/test_config_multi.ini
+++ b/tests/test_config_multi.ini
@@ -120,3 +120,5 @@ int_Q = False
 t      = .25
 [#config cfg_1 RT1_SRF]
 ncoefs = 5
+[#config cfg_1 least_squares_kwargs]
+ftol      = 1.e-3

--- a/tests/test_parallel_processing.py
+++ b/tests/test_parallel_processing.py
@@ -205,7 +205,6 @@ class TestRTfits(unittest.TestCase):
         config_path = Path(__file__).parent.absolute() / "test_config_multi.ini"
 
         proc = RTprocess(config_path)
-
         proc.run_finaloutput(
             ncpu=1,
             finalout_name="ncpu1.nc",
@@ -237,7 +236,7 @@ class TestRTfits(unittest.TestCase):
                 getattr(res, f"dump01__{cfg}")._dump_path.stem == cfg
             ), "multi-result dump-path is not properly set"
 
-    def test_6_multiconfig_props(self):
+    def test_9_multiconfig_props(self):
         # check if properties have been set correctly
 
         res = RTresults("tests/proc_multi")
@@ -250,6 +249,8 @@ class TestRTfits(unittest.TestCase):
         assert str(fit.V.t) == "t_v", "multiconfig props not correct"
         assert fit.SRF.ncoefs == 10, "multiconfig props not correct"
 
+        assert fit.lsq_kwargs["ftol"] == 0.0001, "multiconfig props not correct"
+
         # -----------------------------
 
         fit = getattr(res, "dump01__cfg_1").load_fit()
@@ -260,6 +261,7 @@ class TestRTfits(unittest.TestCase):
 
         assert fit.V.t == 0.25, "multiconfig props not correct"
         assert fit.SRF.ncoefs == 5, "multiconfig props not correct"
+        assert fit.lsq_kwargs["ftol"] == 0.001, "multiconfig props not correct"
 
 
 if __name__ == "__main__":

--- a/tests/test_parallel_processing.py
+++ b/tests/test_parallel_processing.py
@@ -72,23 +72,22 @@ class TestRTfits(unittest.TestCase):
         with self.assertRaises(SystemExit):
             with mock.patch("builtins.input", side_effect=["N"]):
                 proc = RTprocess(config_path, autocontinue=False)
+                proc.setup()
 
         with self.assertRaises(SystemExit):
             with mock.patch("builtins.input", side_effect=["N"]):
-                proc = RTprocess(config_path, autocontinue=False, setup=False)
-                proc.setup()
-        with self.assertRaises(SystemExit):
-            with mock.patch("builtins.input", side_effect=["REMOVE", "N"]):
                 proc = RTprocess(config_path, autocontinue=False)
+                proc.setup()
 
         with mock.patch("builtins.input", side_effect=["REMOVE", "Y"]):
             proc = RTprocess(config_path, autocontinue=False)
+            proc.setup()
         assert (
             len(list(Path("tests/proc_test/dump01/dumps").iterdir())) == 0
         ), "user-input REMOVE did not work"
 
         with mock.patch("builtins.input", side_effect=["REMOVE", "Y"]):
-            proc = RTprocess(config_path, autocontinue=False, copy=False, setup=False)
+            proc = RTprocess(config_path, autocontinue=False, copy=False)
             proc.run_processing(ncpu=1, reader_args=reader_args)
 
         # ----------------------------------------- check if files have been copied
@@ -117,10 +116,13 @@ class TestRTfits(unittest.TestCase):
         reader_args = [dict(gpi=i) for i in [1, 2, 3, 4]]
         config_path = Path(__file__).parent.absolute() / "test_config.ini"
 
-        proc = RTprocess(
-            config_path,
-            autocontinue=True,
-            init_kwargs=dict(path__save_path="tests/proc_test2", dumpfolder="dump02"),
+        proc = RTprocess(config_path, autocontinue=True)
+
+        proc.override_config(
+            PROCESS_SPECS=dict(
+                path__save_path="tests/proc_test2",
+                dumpfolder="dump02",
+            )
         )
 
         proc.run_processing(ncpu=4, reader_args=reader_args)
@@ -147,11 +149,12 @@ class TestRTfits(unittest.TestCase):
         reader_args = [dict(gpi=i) for i in [1, 2, 3, 4]]
 
         with mock.patch("builtins.input", side_effect=["REMOVE", "Y"]):
-            proc = RTprocess(
-                config_path,
-                init_kwargs=dict(
+            proc = RTprocess(config_path)
+
+            proc.override_config(
+                PROCESS_SPECS=dict(
                     path__save_path="tests/proc_test3", dumpfolder="dump03"
-                ),
+                )
             )
 
             proc.run_processing(ncpu=4, reader_args=reader_args, postprocess=False)

--- a/tests/test_parallel_processing.py
+++ b/tests/test_parallel_processing.py
@@ -148,16 +148,12 @@ class TestRTfits(unittest.TestCase):
         config_path = Path(__file__).parent.absolute() / "test_config.ini"
         reader_args = [dict(gpi=i) for i in [1, 2, 3, 4]]
 
-        with mock.patch("builtins.input", side_effect=["REMOVE", "Y"]):
-            proc = RTprocess(config_path)
+        proc = RTprocess(config_path, autocontinue=True)
+        proc.override_config(
+            PROCESS_SPECS=dict(path__save_path="tests/proc_test3", dumpfolder="dump03")
+        )
 
-            proc.override_config(
-                PROCESS_SPECS=dict(
-                    path__save_path="tests/proc_test3", dumpfolder="dump03"
-                )
-            )
-
-            proc.run_processing(ncpu=4, reader_args=reader_args, postprocess=False)
+        proc.run_processing(ncpu=4, reader_args=reader_args, postprocess=False)
 
         results = RTresults("tests/proc_test3")
         assert hasattr(results, "dump03"), "dumpfolder dump02 not found by RTresults"

--- a/tests/test_parallel_processing.py
+++ b/tests/test_parallel_processing.py
@@ -148,7 +148,7 @@ class TestRTfits(unittest.TestCase):
         config_path = Path(__file__).parent.absolute() / "test_config.ini"
         reader_args = [dict(gpi=i) for i in [1, 2, 3, 4]]
 
-        proc = RTprocess(config_path, autocontinue=True)
+        proc = RTprocess(config_path)
         proc.override_config(
             PROCESS_SPECS=dict(path__save_path="tests/proc_test3", dumpfolder="dump03")
         )

--- a/tests/test_parallel_processing.py
+++ b/tests/test_parallel_processing.py
@@ -4,17 +4,17 @@ import unittest.mock as mock
 from rt1.rtprocess import RTprocess, RTresults
 
 import warnings
-warnings.simplefilter('ignore')
+
+warnings.simplefilter("ignore")
 
 
 # use "test_0_---"   "test_1_---"   to ensure test-order
 
 
 class TestRTfits(unittest.TestCase):
-
     def test_0_parallel_processing(self):
         reader_args = [dict(gpi=i) for i in [1, 2, 3, 4]]
-        config_path = Path(__file__).parent.absolute() / 'test_config.ini'
+        config_path = Path(__file__).parent.absolute() / "test_config.ini"
 
         proc = RTprocess(config_path, autocontinue=True)
 
@@ -23,18 +23,27 @@ class TestRTfits(unittest.TestCase):
         # run again to check what happens if files already exist
         proc.run_processing(ncpu=4, reader_args=reader_args)
 
-        #----------------------------------------- check if files have been copied
-        assert Path('tests/proc_test/dump01/cfg').exists(), 'folder-generation did not work'
-        assert Path('tests/proc_test/dump01/results').exists(), 'folder-generation did not work'
-        assert Path('tests/proc_test/dump01/dumps').exists(), 'folder-generation did not work'
-        assert Path('tests/proc_test/dump01/cfg/test_config.ini').exists(), 'copying did not work'
-        assert Path('tests/proc_test/dump01/cfg/parallel_processing_config.py').exists(), 'copying did not work'
-
+        # ----------------------------------------- check if files have been copied
+        assert Path(
+            "tests/proc_test/dump01/cfg"
+        ).exists(), "folder-generation did not work"
+        assert Path(
+            "tests/proc_test/dump01/results"
+        ).exists(), "folder-generation did not work"
+        assert Path(
+            "tests/proc_test/dump01/dumps"
+        ).exists(), "folder-generation did not work"
+        assert Path(
+            "tests/proc_test/dump01/cfg/test_config.ini"
+        ).exists(), "copying did not work"
+        assert Path(
+            "tests/proc_test/dump01/cfg/parallel_processing_config.py"
+        ).exists(), "copying did not work"
 
     def test_1_rtresults(self):
 
-        results = RTresults('tests/proc_test')
-        assert hasattr(results, 'dump01'), 'dumpfolder not found by RTresults'
+        results = RTresults("tests/proc_test")
+        assert hasattr(results, "dump01"), "dumpfolder not found by RTresults"
 
         dumpfiles = [i for i in results.dump01.dump_files]
         print(dumpfiles)
@@ -46,101 +55,125 @@ class TestRTfits(unittest.TestCase):
             processed_ids = list(ncfile.ID.values)
 
         processed_ids.sort()
-        assert processed_ids == [1, 2, 3], 'NetCDF export does not include all IDs'
+        assert processed_ids == [1, 2, 3], "NetCDF export does not include all IDs"
 
         # check if NetCDF_variables works as expected
         results.dump01.NetCDF_variables
 
         # remove the save_path directory
-        #print('deleting save_path directory...')
-        #shutil.rmtree(results._parent_path)
-
+        # print('deleting save_path directory...')
+        # shutil.rmtree(results._parent_path)
 
     def test_2_single_core_processing(self):
         reader_args = [dict(gpi=i) for i in [1, 2, 3, 4]]
-        config_path = Path(__file__).parent.absolute() / 'test_config.ini'
+        config_path = Path(__file__).parent.absolute() / "test_config.ini"
 
         # mock inputs as shown here: https://stackoverflow.com/a/37467870/9703451
         with self.assertRaises(SystemExit):
-            with mock.patch('builtins.input', side_effect=['N']):
+            with mock.patch("builtins.input", side_effect=["N"]):
                 proc = RTprocess(config_path, autocontinue=False)
 
         with self.assertRaises(SystemExit):
-            with mock.patch('builtins.input', side_effect=['N']):
-                proc = RTprocess(config_path, autocontinue=False,
-                                 setup=False)
+            with mock.patch("builtins.input", side_effect=["N"]):
+                proc = RTprocess(config_path, autocontinue=False, setup=False)
                 proc.setup()
         with self.assertRaises(SystemExit):
-            with mock.patch('builtins.input', side_effect=['REMOVE', 'N']):
+            with mock.patch("builtins.input", side_effect=["REMOVE", "N"]):
                 proc = RTprocess(config_path, autocontinue=False)
 
-        with mock.patch('builtins.input', side_effect=['REMOVE', 'Y']):
+        with mock.patch("builtins.input", side_effect=["REMOVE", "Y"]):
             proc = RTprocess(config_path, autocontinue=False)
-        assert len(list(Path('tests/proc_test/dump01/dumps').iterdir())) == 0, 'user-input REMOVE did not work'
+        assert (
+            len(list(Path("tests/proc_test/dump01/dumps").iterdir())) == 0
+        ), "user-input REMOVE did not work"
 
-        with mock.patch('builtins.input', side_effect=['REMOVE', 'Y']):
-            proc = RTprocess(config_path, autocontinue=False,
-                             copy=False, setup=False)
+        with mock.patch("builtins.input", side_effect=["REMOVE", "Y"]):
+            proc = RTprocess(config_path, autocontinue=False, copy=False, setup=False)
             proc.run_processing(ncpu=1, reader_args=reader_args)
 
-        #----------------------------------------- check if files have been copied
-        assert Path('tests/proc_test/dump01/cfg').exists(), 'folder-generation did not work'
-        assert Path('tests/proc_test/dump01/results').exists(), 'folder-generation did not work'
-        assert Path('tests/proc_test/dump01/dumps').exists(), 'folder-generation did not work'
-        assert not Path('tests/proc_test/dump01/cfg/test_config.ini').exists(), 'NOT copying did not work'
-        assert not Path('tests/proc_test/dump01/cfg/parallel_processing_config.py').exists(), 'NOT copying did not work'
+        # ----------------------------------------- check if files have been copied
+        assert Path(
+            "tests/proc_test/dump01/cfg"
+        ).exists(), "folder-generation did not work"
+        assert Path(
+            "tests/proc_test/dump01/results"
+        ).exists(), "folder-generation did not work"
+        assert Path(
+            "tests/proc_test/dump01/dumps"
+        ).exists(), "folder-generation did not work"
+        assert not Path(
+            "tests/proc_test/dump01/cfg/test_config.ini"
+        ).exists(), "NOT copying did not work"
+        assert not Path(
+            "tests/proc_test/dump01/cfg/parallel_processing_config.py"
+        ).exists(), "NOT copying did not work"
 
         # remove the save_path directory
-        #print('deleting save_path directory...')
-        #shutil.rmtree(proc.dumppath.parent)
-
+        # print('deleting save_path directory...')
+        # shutil.rmtree(proc.dumppath.parent)
 
     def test_3_parallel_processing_init_kwargs(self):
         # test overwriting keyword-args from .ini file
         reader_args = [dict(gpi=i) for i in [1, 2, 3, 4]]
-        config_path = Path(__file__).parent.absolute() / 'test_config.ini'
+        config_path = Path(__file__).parent.absolute() / "test_config.ini"
 
-        proc = RTprocess(config_path, autocontinue=True,
-                         init_kwargs=dict(
-                             path__save_path = 'tests/proc_test2',
-                             dumpfolder='dump02')
-                         )
+        proc = RTprocess(
+            config_path,
+            autocontinue=True,
+            init_kwargs=dict(path__save_path="tests/proc_test2", dumpfolder="dump02"),
+        )
 
         proc.run_processing(ncpu=4, reader_args=reader_args)
 
-        #----------------------------------------- check if files have been copied
-        assert Path('tests/proc_test2/dump02/cfg').exists(), 'folder-generation did not work'
-        assert Path('tests/proc_test2/dump02/results').exists(), 'folder-generation did not work'
-        assert Path('tests/proc_test2/dump02/dumps').exists(), 'folder-generation did not work'
-        assert Path('tests/proc_test2/dump02/cfg/test_config.ini').exists(), 'copying did not work'
-        assert Path('tests/proc_test2/dump02/cfg/parallel_processing_config.py').exists(), 'copying did not work'
-
+        # ----------------------------------------- check if files have been copied
+        assert Path(
+            "tests/proc_test2/dump02/cfg"
+        ).exists(), "folder-generation did not work"
+        assert Path(
+            "tests/proc_test2/dump02/results"
+        ).exists(), "folder-generation did not work"
+        assert Path(
+            "tests/proc_test2/dump02/dumps"
+        ).exists(), "folder-generation did not work"
+        assert Path(
+            "tests/proc_test2/dump02/cfg/test_config.ini"
+        ).exists(), "copying did not work"
+        assert Path(
+            "tests/proc_test2/dump02/cfg/parallel_processing_config.py"
+        ).exists(), "copying did not work"
 
     def test_4_postprocess_and_finalout(self):
-        config_path = Path(__file__).parent.absolute() / 'test_config.ini'
+        config_path = Path(__file__).parent.absolute() / "test_config.ini"
         reader_args = [dict(gpi=i) for i in [1, 2, 3, 4]]
 
-        with mock.patch('builtins.input', side_effect=['REMOVE', 'Y']):
-            proc = RTprocess(config_path,
-                             init_kwargs=dict(
-                                 path__save_path='tests/proc_test3',
-                                 dumpfolder='dump03'))
+        with mock.patch("builtins.input", side_effect=["REMOVE", "Y"]):
+            proc = RTprocess(
+                config_path,
+                init_kwargs=dict(
+                    path__save_path="tests/proc_test3", dumpfolder="dump03"
+                ),
+            )
 
-            proc.run_processing(ncpu=4, reader_args=reader_args,
-                                postprocess=False)
+            proc.run_processing(ncpu=4, reader_args=reader_args, postprocess=False)
 
-        results = RTresults('tests/proc_test3')
-        assert hasattr(results, 'dump03'), 'dumpfolder dump02 not found by RTresults'
+        results = RTresults("tests/proc_test3")
+        assert hasattr(results, "dump03"), "dumpfolder dump02 not found by RTresults"
 
-        finalout_name = results.dump03.load_cfg().get_process_specs()['finalout_name']
+        finalout_name = results.dump03.load_cfg().get_process_specs()["finalout_name"]
 
-        assert not Path(f'tests/proc_test3/dump03/results/{finalout_name}.nc').exists(), 'disabling postprocess did not work'
+        assert not Path(
+            f"tests/proc_test3/dump03/results/{finalout_name}.nc"
+        ).exists(), "disabling postprocess did not work"
 
-        proc.run_finaloutput(ncpu=1, finalout_name='ncpu_1.nc')
-        assert Path('tests/proc_test3/dump03/results/ncpu_1.nc').exists(), 'run_finalout with ncpu=1 not work'
+        proc.run_finaloutput(ncpu=1, finalout_name="ncpu_1.nc")
+        assert Path(
+            "tests/proc_test3/dump03/results/ncpu_1.nc"
+        ).exists(), "run_finalout with ncpu=1 not work"
 
-        proc.run_finaloutput(ncpu=4, finalout_name='ncpu_2.nc')
-        assert Path('tests/proc_test3/dump03/results/ncpu_2.nc').exists(), 'run_finalout with ncpu=2 not work'
+        proc.run_finaloutput(ncpu=4, finalout_name="ncpu_2.nc")
+        assert Path(
+            "tests/proc_test3/dump03/results/ncpu_2.nc"
+        ).exists(), "run_finalout with ncpu=2 not work"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### introduce mutliconfig `.ini` files

- directly provide multiple configuration-specifications that will be evaluated without multiple calls to the reader

specify multi-configs via:
```ini
[defdict] # the common values for all configs
key = val
key_1 = val_1

[#config NAME defdict] # the values that will be updated when running this config
key = val
```