### PR TITLE
speed-up of processing

### DIFF
--- a/rt1/__init__.py
+++ b/rt1/__init__.py
@@ -160,7 +160,7 @@ def _get_logger_formatter(simple=True):
 def setup_logger(
     log_name="rt1",
     console_out=True,
-    console_level=logging.WARNING,
+    console_level=21,
     simple=True,
 ):
 

--- a/rt1/rtfits.py
+++ b/rt1/rtfits.py
@@ -1378,9 +1378,9 @@ class Fits(Scatter):
             )
             return
 
-        vals = self._assignvals(self.res_dict)
+        vals = dict()
         for key, val in self._assignvals(self.res_dict).items():
-            vals[key] = vals[key][~self.mask]
+            vals[key] = val[~self.mask]
 
         resdf = (
             pd.DataFrame(vals, list(chain(*self._orig_index))
@@ -2948,14 +2948,14 @@ class MultiFits:
             name
         ), f"the name {name} is not a valid python identifier!"
 
-        # make sure that the config-name do not overwrite any definitions
-        assert name not in set(self.__dict__) ^ set(
-            self.config_names
-        ), f"you can not use {name} as the name for a configuration!"
+        # make sure that the config-name does not overwrite any definitions
+        assert name not in set(self.__dict__),(
+            f"you can not use {name} as the name for a configuration!")
         self.config_names.append(name)
 
         fit_object.dataset = self.dataset
         fit_object.aux_data = self.aux_data
+        fit_object.config_name = name
         setattr(self.configs, name, fit_object)
 
     def dump(self, path, mini=True):

--- a/rt1/rtfits.py
+++ b/rt1/rtfits.py
@@ -2956,7 +2956,7 @@ class MultiFits:
         ), f"the name {name} is not a valid python identifier!"
 
         # make sure that the config-name does not overwrite any definitions
-        assert name not in set(self.__dict__),(
+        assert name not in set(self.__dict__), (
             f"you can not use {name} as the name for a configuration!")
         self.config_names.append(name)
 

--- a/rt1/rtfits.py
+++ b/rt1/rtfits.py
@@ -78,22 +78,32 @@ class Fits(Scatter):
         Indicator whether dataset is given in linear units or in dB.
         The applied relation is:    x_dB = 10. * np.log10( x_linear )
     dataset: pandas.DataFrame (default = None)
-             a pandas.DataFrame with columns `inc` and `sig` defined
-             where `inc` referrs to the incidence-angle in radians, and
-             `sig` referrs to the measurement value (corresponding to
-             the assigned sig0 and dB values)
+             a pandas.DataFrame that has (at least) the following columns defined:
 
-             - If a column `data_weights` is provided, the residuals in the
+             - `"inc"`: the incidence-angle in radians
+             - `"sig"`: the backscatter measurement value, e.g.:
+              - backscattering coefficient if "sig0" is set to True or
+                intensity if "sig0" is set to False
+              - the parameter "dB" indicates if the values are provided in dB or not
+
+             - If a column `"data_weights"` is provided, the residuals in the
                fit-procedure will be weighted accordingly.
-               (e.g. residuals = weights * calculated_residuals )
-             - If columns `param_dyn` are provided where `param` is the name of
-               a parameter that is intended to be fitted, the entries will be
-               used to assign the dynamics of the corresponding parameter
-               (see defdict 'freq' entry for further details)
-             - If columns with names corresponding to parameters are provided
-               and the corresponding entry in the 'val' parameter of defdict
-               is set to 'auxiliary', then the provided data will be used
-               as auxiliary data for the parameter.
+               (e.g. residuals = data_weights * calculated_residuals )
+             - If columns `"<param>_dyn"` are provided where `<param>` is the name of
+               a parameter that is intended to be fitted, the positions of the unique
+               entries will be used to assign the dynamics of the corresponding
+               parameter (see defdict 'freq' entry for further details)
+
+               >>> defdict = {"X" : [True, .1, 'manual', ([0.], [1.]), False]}
+               >>> dataset['X_dyn'] = [1, 1, 1, 2, 2, 1, 1, 3, 3, 5, ...]
+
+             - If columns that match parameter-names are provided and the corresponding
+               entry in the `"val"` parameter of defdict is set to `"auxiliary"`, then
+               the provided data will be used as auxiliary data for the parameter.
+
+               >>> defdict = {"X" : [False, 'auxiliary']}
+               >>> dataset["X"] = ... the data to use for the "X" parameter...
+
 
     defdict: dict (default = None)
              a dictionary of the following structure:

--- a/rt1/rtfits.py
+++ b/rt1/rtfits.py
@@ -2839,6 +2839,13 @@ class MultiFits:
         else:
             self.set_reader_arg(reader_arg)
 
+    def __setstate__(self, d):
+        self.__dict__ = d
+        # this is done to support downward-compatibility with pickled results
+        for name, fit in self.accessor.config_fits.items():
+            if not hasattr(fit, "config_name"):
+                fit.config_name = name
+
     @property
     def dataset(self):
         return self._dataset

--- a/rt1/rtfits.py
+++ b/rt1/rtfits.py
@@ -163,7 +163,17 @@ class Fits(Scatter):
                >>>     return V, SRF
 
                or a dict that will be passed to _init_V_SRF() to initialize
-               the V- and SRF-objects
+               the V- and SRF-objects of the form:
+
+               >>> dict(
+               >>>    V_props=dict(
+               >>>            V_name="Volume-function",
+               >>>            ... volume-keys ...),
+               >>>    SRF_props=dict(
+               >>>            SRF_name="Surface-function",
+               >>>            ... surface-keys ...)
+               >>>    )
+
     lsq_kwargs: dict (default = dict())
                 a dictionary with keyword-arguments passed to
                 scipy.optimize.least_squares

--- a/rt1/rtfits.py
+++ b/rt1/rtfits.py
@@ -473,7 +473,8 @@ class Fits(Scatter):
         else:
 
             # the names of the parameters that will be fitted
-            dyn_keys = [key for key, val in self.defdict.items() if val[0] is True]
+            dyn_keys = [key for key, val in self.defdict.items()
+                        if val[0] is True]
 
             # set frequencies of fitted parameters
             # (group by similar frequencies)
@@ -605,7 +606,8 @@ class Fits(Scatter):
         """
 
         # find the max. length of the parameters
-        maxdict = {key: len(str(max(val))) for key, val in self.param_dyn_dict.items()}
+        maxdict = {key: len(str(max(val)))
+                   for key, val in self.param_dyn_dict.items()}
         # find the max. length of the parameters
 
         def doit(x, N):
@@ -615,7 +617,8 @@ class Fits(Scatter):
             if i == 0:
                 conclist = list(map(partial(doit, N=maxdict[key]), val))
             else:
-                conclist = map(add, conclist, map(partial(doit, N=maxdict[key]), val))
+                conclist = map(add, conclist, map(
+                    partial(doit, N=maxdict[key]), val))
         return np.array(list(map(int, conclist)))
 
     @property
@@ -632,7 +635,8 @@ class Fits(Scatter):
             return
         # don't use keys that are not provided in defdict
         # (e.g. "param_dyn" keys and additional datasets irrelevant to the fit)
-        usekeys = ["sig", "inc"] + [key for key in self.defdict if key in self.dataset]
+        usekeys = ["sig", "inc"] + \
+            [key for key in self.defdict if key in self.dataset]
         if "data_weights" in self.dataset:
             usekeys += ["data_weights"]
 
@@ -909,7 +913,8 @@ class Fits(Scatter):
         """indices of each parameter-group (to re-assign to the data-index)"""
         assigndict = dict()
         for key, val in self.param_dyn_dict.items():
-            assigndict[key] = groupby_unsorted(range(len(val)), key=lambda x: val[x])
+            assigndict[key] = groupby_unsorted(
+                range(len(val)), key=lambda x: val[x])
 
         return assigndict
 
@@ -996,7 +1001,8 @@ class Fits(Scatter):
                     )
                     meanstartvals = list(
                         groupby_unsorted(
-                            zip(self._groupindex, self.dataset[key + "_start"]),
+                            zip(self._groupindex,
+                                self.dataset[key + "_start"]),
                             key=itemgetter(0),
                             get=itemgetter(1),
                         ).values()
@@ -1207,7 +1213,8 @@ class Fits(Scatter):
         if callable(self.set_V_SRF):
             _, SRF = self.set_V_SRF(**self._setdict)
         elif isinstance(self.set_V_SRF, dict):
-            SRF = self._init_V_SRF(self.set_V_SRF["SRF_props"], setdict=self._setdict)
+            SRF = self._init_V_SRF(
+                self.set_V_SRF["SRF_props"], setdict=self._setdict)
         return SRF
 
     @property
@@ -1246,7 +1253,8 @@ class Fits(Scatter):
     def _get_V_SRF_symbs(self, V_SRF, prop):
         """the symbols used to define tau, omega and NormBRDF of V and SRF"""
         try:
-            symbs = list(map(str, getattr(getattr(self, V_SRF), prop).free_symbols))
+            symbs = list(
+                map(str, getattr(getattr(self, V_SRF), prop).free_symbols))
         except Exception:
             symbs = list()
         return symbs
@@ -1343,7 +1351,8 @@ class Fits(Scatter):
             vals[key] = vals[key][~self.mask]
 
         resdf = (
-            pd.DataFrame(vals, list(chain(*self._orig_index))).groupby(level=0).first()
+            pd.DataFrame(vals, list(chain(*self._orig_index))
+                         ).groupby(level=0).first()
         )
 
         return resdf
@@ -1793,7 +1802,8 @@ class Fits(Scatter):
 
         # same for NormBRDF
         for i in set(self._N_symb) & set(param_dyn_dict.keys()):
-            df_dx = self._N_diff_func[i](**{key: res_dict[key] for key in self._N_symb})
+            df_dx = self._N_diff_func[i](
+                **{key: res_dict[key] for key in self._N_symb})
             if not np.isscalar(df_dx):
                 df_dx = np.fromiter(chain(*df_dx), dtype=float, count=jac_size)
 
@@ -1918,7 +1928,8 @@ class Fits(Scatter):
             if "tau" in res_dict:
                 R.V.tau = res_dict["tau"]
         else:
-            R.V.tau = self._tau_func(**{key: res_dict[key] for key in self._tau_symb})
+            R.V.tau = self._tau_func(
+                **{key: res_dict[key] for key in self._tau_symb})
 
         if self._N_func is None:
             if "NormBRDF" in res_dict:
@@ -2391,7 +2402,8 @@ class Fits(Scatter):
                 else:
                     vari = "      -       "
 
-                boun = (f"{val[3][0][0]:.5}" + "-" + f"{val[3][1][0]:.5}").ljust(13)
+                boun = (f"{val[3][0][0]:.5}" + "-" +
+                        f"{val[3][1][0]:.5}").ljust(13)
                 try:
                     inte = f"{str(val[4]):<14}"
                 except IndexError:
@@ -2417,7 +2429,8 @@ class Fits(Scatter):
             vvals = list(vprop.values())
 
             srfnames = list(srfprop.keys())
-            srfnames = [i.ljust(max(map(len, srfnames))) + ":" for i in srfnames]
+            srfnames = [i.ljust(max(map(len, srfnames))) +
+                        ":" for i in srfnames]
             srfvals = list(srfprop.values())
 
             while len(vnames) < max(len(vnames), len(srfnames)):
@@ -2505,7 +2518,7 @@ class Fits(Scatter):
         if len(lsqkw) > 0:
             outstr += "\n\n# LSQ PARAMETERS " + "\n"
             for key1, key2 in zip(
-                keys[: (len(keys) + 1) // 2], keys[(len(keys) + 1) // 2 :]
+                keys[: (len(keys) + 1) // 2], keys[(len(keys) + 1) // 2:]
             ):
                 outstr += (
                     f" {key1:<15}= {lsqkw[key1]}".ljust(37)
@@ -2696,7 +2709,8 @@ class _MultiAccessors:
                     self,
                     prop,
                     update_wrapper(
-                        partial(self._applyit, prop=prop), getattr(Fits(), prop)
+                        partial(self._applyit, prop=prop), getattr(
+                            Fits(), prop)
                     ),
                 )
             elif isinstance(getattr(Fits, prop), property):
@@ -2873,7 +2887,8 @@ class MultiFits:
             )
         elif isinstance(use_config, str):
             return [
-                (use_config, f(fit=self.accessor.config_fits[use_config], **kwargs))
+                (use_config, f(
+                    fit=self.accessor.config_fits[use_config], **kwargs))
             ]
         elif isinstance(use_config, list):
             return (
@@ -2898,7 +2913,8 @@ class MultiFits:
             the fit-object
         """
         if name in self.config_names:
-            log.warning(f"the config {name} will be overwritten by the new definition!")
+            log.warning(
+                f"the config {name} will be overwritten by the new definition!")
 
         assert str.isidentifier(
             name

--- a/rt1/rtplots.py
+++ b/rt1/rtplots.py
@@ -113,10 +113,8 @@ def polarplot(
     if X is None:
         assert False, "Error: You must provide a volume- or surface object!"
 
-
     if isinstance(param_dict, dict):
         param_dict = [param_dict]
-
 
     if polarax is None:
         fig = plt.figure(figsize=(7, 7))

--- a/rt1/rtplots.py
+++ b/rt1/rtplots.py
@@ -89,6 +89,11 @@ def polarplot(
 
                  >>> polarax = fig.add_subplot(111, projection='polar')
 
+    param_dict : list of dict's
+                 a dictionary (or a list of dictionaries) that contains the
+                 names and values of the symbolic parameters required to define
+                 the V/SRF functions
+
     Returns
     ---------
     polarfig : figure

--- a/rt1/rtplots.py
+++ b/rt1/rtplots.py
@@ -1704,6 +1704,8 @@ class plot:
 
         for key, val in sig0_vals.items():
             sig0_vals[key] = val[inc_sortp]
+        for key, val in sig0_vals_I_linear.items():
+            sig0_vals_I_linear[key] = val[inc_sortp]
         for key, val in newsig0_vals.items():
             newsig0_vals[key] = val[inc_sortp]
         for key, val in newsig0_vals_I_linear.items():

--- a/rt1/rtprocess.py
+++ b/rt1/rtprocess.py
@@ -470,11 +470,16 @@ class RTprocess(object):
         # from the copied file
         copypath = self.dumppath / "cfg" / self.cfg.configpath.name
         if mp.current_process().name == "MainProcess":
-            if (copypath).exists() and len(self.init_kwargs) == 0:
+            if copypath.exists() and len(self.init_kwargs) == 0:
+
                 log.warning(
-                    f'the file \n"{copypath}"\n'
+                    f'the file "{Path(*copypath.parts[-3:])} "'
                     + "already exists... NO copying is performed and the "
                     + "existing one is used!\n"
+                )
+
+                log.debug(
+                    f'{copypath.name} imported from \n"{copypath}"\n'
                 )
             else:
                 if len(self.init_kwargs) == 0:
@@ -512,10 +517,15 @@ class RTprocess(object):
 
                     if module_copypath.exists():
                         log.warning(
-                            f'the file \n"{module_copypath}" \nalready '
-                            + "exists ... NO copying is performed "
-                            + "and the existing one is used!\n"
+                            f'the file "{Path(*module_copypath.parts[-3:])} "'
+                            + "already exists... NO copying is performed and the "
+                            + "existing one is used!\n"
                         )
+
+                        log.debug(
+                            f'{module_copypath.name} imported from \n"{module_copypath}"\n'
+                        )
+
                     else:
                         shutil.copy(location, module_copypath)
                         log.info(f'"{location.name}" copied to \n"{module_copypath}"')
@@ -832,10 +842,6 @@ class RTprocess(object):
             for name, parent_fit in self.parent_fit.accessor.config_fits.items():
                 if parent_fit.int_Q is True:
                     parent_fit._fnevals_input = parent_fit.R._fnevals
-        # if len(self.cfg.config_names) > 0:
-        #     for i, [cfg_name, parent_fit] in enumerate(self.parent_fit):
-        #         if parent_fit.int_Q is True:
-        #             parent_fit._fnevals_input = parent_fit.R._fnevals
         else:
             if self.parent_fit.int_Q is True:
                 self.parent_fit._fnevals_input = self.parent_fit.R._fnevals

--- a/rt1/rtprocess.py
+++ b/rt1/rtprocess.py
@@ -308,10 +308,9 @@ class RTprocess(object):
         (use override=False to update `init_kwargs`)
 
         kwargs must be passed in the form:
-        ```
-        section = dict( key1 = val1,
-                        key2 = val2, ... )
-        ```
+
+        >>> section = dict( key1 = val1,
+        >>>                 key2 = val2, ... )
 
         Parameters
         ----------

--- a/rt1/rtprocess.py
+++ b/rt1/rtprocess.py
@@ -364,7 +364,6 @@ class RTprocess(object):
           - copy modules and .ini files (if copy=True) (only from MainProcess!)
           - load modules and set parent-fit-object
         """
-
         self.cfg = RT1_configparser(self.config_path)
 
         # update specs with init_kwargs
@@ -682,13 +681,14 @@ class RTprocess(object):
         (>> returns from provided initializer are returned)
         """
 
+        if queue is not None:
+            self._worker_configurer(queue)
+
         if not mp.current_process().name == "MainProcess":
             # call setup() on each worker-process to ensure that the importer loads
             # all required modules from the desired locations
+            log.warning("setting up RTprocess-worker")
             self.setup()
-
-        if queue is not None:
-            self._worker_configurer(queue)
 
         if initializer is not None:
             res = initializer(*args)

--- a/rt1/rtprocess.py
+++ b/rt1/rtprocess.py
@@ -138,7 +138,7 @@ def _increase_cnt(process_cnt, start, err=False):
                 ),
                 progress2=p_totcnt.value - p_meancnt.value,
             )
-            log.progress(msg.strip())
+
         else:
             # only increase the total counter
             p_totcnt.value += 1
@@ -162,7 +162,9 @@ def _increase_cnt(process_cnt, start, err=False):
                 ),
                 progress2=p_totcnt.value - p_meancnt.value,
             )
-            log.progress(msg.strip())
+
+            # log to file if an error occured during processing
+            log.debug(msg.strip())
 
         if lock is not None:
             # release the lock
@@ -697,7 +699,7 @@ class RTprocess(object):
         if not mp.current_process().name == "MainProcess":
             # call setup() on each worker-process to ensure that the importer loads
             # all required modules from the desired locations
-            log.warning("setting up RTprocess-worker")
+            log.progress("setting up RTprocess-worker")
             self.setup()
 
         if initializer is not None:

--- a/rt1/scatter.py
+++ b/rt1/scatter.py
@@ -2,7 +2,7 @@
 
 # general other imports
 import sympy as sp
-
+import numpy as np
 
 class Scatter(object):
     """The basis object for any Surface and Volume objects"""
@@ -52,6 +52,14 @@ class Scatter(object):
             a[0] * sp.cos(t_0) * sp.cos(t_ex)
             + a[1] * sp.sin(t_0) * sp.sin(t_ex) * sp.cos(p_0) * sp.cos(p_ex)
             + a[2] * sp.sin(t_0) * sp.sin(t_ex) * sp.sin(p_0) * sp.sin(p_ex)
+        )
+
+    def _scat_angle_numeric(self, t_0, t_ex, p_0, p_ex, a):
+        # a numeric version of scat_angle
+        return (
+            a[0] * np.cos(t_0) * np.cos(t_ex)
+            + a[1] * np.sin(t_0) * np.sin(t_ex) * np.cos(p_0) * np.cos(p_ex)
+            + a[2] * np.sin(t_0) * np.sin(t_ex) * np.sin(p_0) * np.sin(p_ex)
         )
 
     def _get_legcoef(self, n0):

--- a/rt1/surface.py
+++ b/rt1/surface.py
@@ -540,9 +540,15 @@ class Isotropic(Surface):
         super(Isotropic, self).__init__(**kwargs)
 
     @property
+    def ncoefs(self):
+        # make ncoefs a property since it is fixed and should not be changed
+        # only 1 coefficient is needed to correctly represent
+        # the Isotropic scattering function
+        return 1
+
+    @property
     @lru_cache()
     def legcoefs(self):
-        self.ncoefs = 1
         n = sp.Symbol("n")
         return (1.0 / sp.pi) * sp.KroneckerDelta(0, n)
 

--- a/rt1/surface.py
+++ b/rt1/surface.py
@@ -466,7 +466,7 @@ class LinCombSRF(Surface):
                 super(BRDFfunction, self).__init__(**kwargs)
 
                 self._func = 0.0
-                self._legcoefs = 0.0
+                self.legcoefs = 0.0
 
         # initialize a combined phase-function class element
         SRFcomb = BRDFfunction(NormBRDf=self.NormBRDF)

--- a/rt1/surface.py
+++ b/rt1/surface.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import sympy as sp
-from functools import partial, update_wrapper
+from functools import partial, update_wrapper, lru_cache
 
 from .scatter import Scatter
 from .rtplots import polarplot, hemreflect
@@ -25,6 +25,24 @@ class Surface(Scatter):
         # quick way for visualizing the associated hemispherical reflectance
         self.hemreflect = partial(hemreflect, SRF=self)
         update_wrapper(self.hemreflect, hemreflect)
+
+    @lru_cache()
+    def _lambda_func(self, *args):
+        # define sympy objects
+        theta_0 = sp.Symbol("theta_0")
+        theta_ex = sp.Symbol("theta_ex")
+        phi_0 = sp.Symbol("phi_0")
+        phi_ex = sp.Symbol("phi_ex")
+
+        # replace arguments and evaluate expression
+        # sp.lambdify is used to allow array-inputs
+        # for python > 3.5 unpacking could be used, i.e.:
+        # pfunc = sp.lambdify((theta_0, theta_ex, phi_0, phi_ex,
+        #                     *param_dict.keys()),
+        #                    self._func, modules=["numpy", "sympy"])
+        args = (theta_0, theta_ex, phi_0, phi_ex) + tuple(args)
+        pfunc = sp.lambdify(args, self._func, modules=["numpy", "sympy"])
+        return pfunc
 
     def brdf(self, t_0, t_ex, p_0, p_ex, param_dict={}):
         """
@@ -52,10 +70,10 @@ class Surface(Scatter):
         """
 
         # define sympy objects
-        theta_0 = sp.Symbol("theta_0")
-        theta_ex = sp.Symbol("theta_ex")
-        phi_0 = sp.Symbol("phi_0")
-        phi_ex = sp.Symbol("phi_ex")
+        # theta_0 = sp.Symbol("theta_0")
+        # theta_ex = sp.Symbol("theta_ex")
+        # phi_0 = sp.Symbol("phi_0")
+        # phi_ex = sp.Symbol("phi_ex")
 
         # replace arguments and evaluate expression
         # sp.lambdify is used to allow array-inputs
@@ -63,9 +81,9 @@ class Surface(Scatter):
         # brdffunc = sp.lambdify((theta_0, theta_ex, phi_0, phi_ex,
         #                        *param_dict.keys()),
         #                       self._func, modules=["numpy", "sympy"])
-        args = (theta_0, theta_ex, phi_0, phi_ex) + tuple(param_dict.keys())
-        brdffunc = sp.lambdify(args, self._func, modules=["numpy", "sympy"])
-
+        # args = (theta_0, theta_ex, phi_0, phi_ex) + tuple(param_dict.keys())
+        # brdffunc = sp.lambdify(args, self._func, modules=["numpy", "sympy"])
+        brdffunc = self._lambda_func(*param_dict.keys())
         # in case _func is a constant, lambdify will produce a function with
         # scalar output which is not suitable for further processing
         # (this happens e.g. for the Isotropic brdf).

--- a/rt1/volume.py
+++ b/rt1/volume.py
@@ -565,6 +565,14 @@ class Rayleigh(Volume):
     def __init__(self, **kwargs):
         super(Rayleigh, self).__init__(**kwargs)
 
+
+    @property
+    def ncoefs(self):
+        # make ncoefs a property since it is fixed and should not be changed
+        # only 3 coefficients are needed to correctly represent
+        # the Rayleigh scattering function
+        return 3
+
     @property
     @lru_cache()
     def _func(self):
@@ -585,7 +593,6 @@ class Rayleigh(Volume):
         """
         # only 3 coefficients are needed to correctly represent
         # the Rayleigh scattering function
-        self.ncoefs = 3
         n = sp.Symbol("n")
         return (
             (3.0 / (16.0 * sp.pi))

--- a/rt1/volume.py
+++ b/rt1/volume.py
@@ -34,10 +34,6 @@ class Volume(Scatter):
 
         # replace arguments and evaluate expression
         # sp.lambdify is used to allow array-inputs
-        # for python > 3.5 unpacking could be used, i.e.:
-        # pfunc = sp.lambdify((theta_0, theta_ex, phi_0, phi_ex,
-        #                     *param_dict.keys()),
-        #                    self._func, modules=["numpy", "sympy"])
         args = (theta_0, theta_ex, phi_0, phi_ex) + tuple(args)
         pfunc = sp.lambdify(args, self._func, modules=["numpy", "sympy"])
         return pfunc
@@ -67,22 +63,13 @@ class Volume(Scatter):
         array_like(float)
             Numerical value of the volume-scattering phase-function
         """
-        # define sympy objects
-        #theta_0 = sp.Symbol("theta_0")
-        #theta_ex = sp.Symbol("theta_ex")
-        #phi_0 = sp.Symbol("phi_0")
-        #phi_ex = sp.Symbol("phi_ex")
 
-        # replace arguments and evaluate expression
-        # sp.lambdify is used to allow array-inputs
-        # for python > 3.5 unpacking could be used, i.e.:
-        # pfunc = sp.lambdify((theta_0, theta_ex, phi_0, phi_ex,
-        #                     *param_dict.keys()),
-        #                    self._func, modules=["numpy", "sympy"])
-        #args = (theta_0, theta_ex, phi_0, phi_ex) + tuple(param_dict.keys())
-        #pfunc = sp.lambdify(args, self._func, modules=["numpy", "sympy"])
-        pfunc = self._lambda_func(*param_dict.keys())
-        #pfunc = self._func_numeric
+        # if an explicit numeric function is provided, use it, otherwise
+        # lambdify the available sympy-function
+        if hasattr(self, "_func_numeric"):
+            pfunc = self._func_numeric
+        else:
+            pfunc = self._lambda_func(*param_dict.keys())
         # in case _func is a constant, lambdify will produce a function with
         # scalar output which is not suitable for further processing
         # (this happens e.g. for the Isotropic brdf).
@@ -450,13 +437,13 @@ class LinCombV(Volume):
         super(LinCombV, self).__init__(**kwargs)
 
         self.Vchoices = Vchoices
-        self._set_function()
-        self._set_legexpansion()
 
-    def _set_function(self):
+    @property
+    @lru_cache()
+    def _func(self):
         """define phase function as sympy object for later evaluation"""
 
-        self._func = self._Vcombiner()._func
+        return self._Vcombiner()._func
 
     def _set_legexpansion(self):
         """set legexpansion to the combined legexpansion"""
@@ -494,21 +481,7 @@ class LinCombV(Volume):
 
             def __init__(self, **kwargs):
                 super(Phasefunction, self).__init__(**kwargs)
-                self._set_function()
-                self._set_legcoefficients()
-
-            def _set_function(self):
-                """def phase function as sympy object for later evaluation"""
-
                 self._func = 0.0
-
-            def _set_legcoefficients(self):
-                """
-                set Legrende coefficients
-                needs to be a function that can be later evaluated by
-                subsituting 'n'
-                """
-
                 self.legcoefs = 0.0
 
         # find phase functions with equal a parameters
@@ -591,19 +564,21 @@ class Rayleigh(Volume):
 
     def __init__(self, **kwargs):
         super(Rayleigh, self).__init__(**kwargs)
-        self._set_function()
-        self._set_legcoefficients()
 
-    def _set_function(self):
+    @property
+    @lru_cache()
+    def _func(self):
         """define phase function as sympy object for later evaluation"""
         theta_0 = sp.Symbol("theta_0")
         theta_ex = sp.Symbol("theta_ex")
         phi_0 = sp.Symbol("phi_0")
         phi_ex = sp.Symbol("phi_ex")
         x = self.scat_angle(theta_0, theta_ex, phi_0, phi_ex, self.a)
-        self._func = 3.0 / (16.0 * sp.pi) * (1.0 + x ** 2.0)
+        return 3.0 / (16.0 * sp.pi) * (1.0 + x ** 2.0)
 
-    def _set_legcoefficients(self):
+    @property
+    @lru_cache()
+    def legcoefs(self):
         """
         set Legrende coefficients
         needs to be a function that can be later evaluated by subsituting 'n'
@@ -612,7 +587,7 @@ class Rayleigh(Volume):
         # the Rayleigh scattering function
         self.ncoefs = 3
         n = sp.Symbol("n")
-        self.legcoefs = (
+        return (
             (3.0 / (16.0 * sp.pi))
             * (
                 (4.0 / 3.0) * sp.KroneckerDelta(0, n)
@@ -659,27 +634,45 @@ class HenyeyGreenstein(Volume):
         )
         self.ncoefs = ncoefs
         assert self.ncoefs > 0
-        self._set_function()
-        self._set_legcoefficients()
 
-    def _set_function(self):
+    @property
+    @lru_cache()
+    def _func(self):
         """define phase function as sympy object for later evaluation"""
         theta_0 = sp.Symbol("theta_0")
         theta_ex = sp.Symbol("theta_ex")
         phi_0 = sp.Symbol("phi_0")
         phi_ex = sp.Symbol("phi_ex")
         x = self.scat_angle(theta_0, theta_ex, phi_0, phi_ex, self.a)
-        self._func = (1.0 - self.t ** 2.0) / (
+        func = (1.0 - self.t ** 2.0) / (
             (4.0 * sp.pi) * (1.0 + self.t ** 2.0 - 2.0 * self.t * x) ** 1.5
         )
 
-    def _set_legcoefficients(self):
+        return func
+
+    def _func_numeric(self, theta_0, theta_ex, phi_0, phi_ex, **kwargs):
+        """direct numeric version of _func"""
+        if len(self.free_symbols) > 0:
+            t = kwargs[list(self.free_symbols)[0]]
+        else:
+            t = self.t
+        x = self._scat_angle_numeric(theta_0, theta_ex, phi_0, phi_ex, self.a)
+        func = (1.0 - t ** 2.0) / (
+            (4.0 * np.pi) * (1.0 + t ** 2.0 - 2.0 * t * x) ** 1.5
+        )
+
+        return func
+
+    @property
+    @lru_cache()
+    def legcoefs(self):
         """
         set Legrende coefficients
         needs to be a function that can be later evaluated by subsituting 'n'
         """
         n = sp.Symbol("n")
-        self.legcoefs = (1.0 / (4.0 * sp.pi)) * (2.0 * n + 1) * self.t ** n
+        legcoefs = (1.0 / (4.0 * sp.pi)) * (2.0 * n + 1) * self.t ** n
+        return legcoefs
 
 
 class HGRayleigh(Volume):
@@ -728,17 +721,17 @@ class HGRayleigh(Volume):
         )
         self.ncoefs = ncoefs
         assert self.ncoefs > 0
-        self._set_function()
-        self._set_legcoefficients()
 
-    def _set_function(self):
+    @property
+    @lru_cache()
+    def _func(self):
         """define phase function as sympy object for later evaluation"""
         theta_0 = sp.Symbol("theta_0")
         theta_ex = sp.Symbol("theta_ex")
         phi_0 = sp.Symbol("phi_0")
         phi_ex = sp.Symbol("phi_ex")
         x = self.scat_angle(theta_0, theta_ex, phi_0, phi_ex, self.a)
-        self._func = (
+        return (
             3.0
             / (8.0 * sp.pi)
             * (
@@ -750,13 +743,15 @@ class HGRayleigh(Volume):
             )
         )
 
-    def _set_legcoefficients(self):
+    @property
+    @lru_cache()
+    def legcoefs(self):
         """
         set Legrende coefficients
         needs to be a function that can be later evaluated by subsituting 'n'
         """
         n = sp.Symbol("n")
-        self.legcoefs = sp.Piecewise(
+        return sp.Piecewise(
             (
                 3.0
                 / (8.0 * sp.pi)

--- a/rt1/volume.py
+++ b/rt1/volume.py
@@ -652,8 +652,8 @@ class HenyeyGreenstein(Volume):
 
     def _func_numeric(self, theta_0, theta_ex, phi_0, phi_ex, **kwargs):
         """direct numeric version of _func"""
-        if len(self.free_symbols) > 0:
-            t = kwargs[list(self.free_symbols)[0]]
+        if isinstance(self.t, sp.Symbol):
+            t = kwargs[str(self.t)]
         else:
             t = self.t
         x = self._scat_angle_numeric(theta_0, theta_ex, phi_0, phi_ex, self.a)


### PR DESCRIPTION
## new
- add possibility to provide numeric V & SRF functions for faster evaluation if no interaction-term is calculated
- add a property `fit.config_name` to fits that originate from a MultiFits object
- make sure datasets provided to `rtfits.Fits` are sorted prior to processing

## fixes
- make `ncoefs` a propery for "Rayleigh" and "Isotropic" phase-functions
- improved logging messages (don't log each successful progress step, only errors and warnings)
- pre-evaluate fn-coefficients during finalout-generation
- fix sorting of fractional contributions in `rtplots.printsig0analysis()`
- some updates on `rtplots.polarplot()` for symbolic parameter specification


