### PR TITLE
Dev

### DIFF
--- a/.github/workflows/RT1_ubuntu.yml
+++ b/.github/workflows/RT1_ubuntu.yml
@@ -10,7 +10,7 @@ jobs:
         # set operating systems to test
         os: [ubuntu-latest]
         # set python versions to test
-        python-version: ['3.6', '3.7']
+        python-version: ['3.7']
 
     name: RT1_test ${{ matrix.os }}  ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/RT1_windows.yml
+++ b/.github/workflows/RT1_windows.yml
@@ -10,7 +10,7 @@ jobs:
         # set operating systems to test
         os: [windows-latest]
         # set python versions to test
-        python-version: ['3.6', '3.7']
+        python-version: ['3.7']
 
     name: RT1_test ${{ matrix.os }}  ${{ matrix.python-version }}
     steps:

--- a/rt1/rtfits.py
+++ b/rt1/rtfits.py
@@ -56,7 +56,7 @@ def load(path):
     """
 
     with open(path, "rb") as file:
-        fit = cloudpickle.load(file)
+        fit = pd.read_pickle(file)
 
     return fit
 

--- a/tests/test_env.yml
+++ b/tests/test_env.yml
@@ -6,7 +6,7 @@ dependencies:
   - numpy
   - sympy
   - scipy
-  - pandas<1.3
+  - pandas
   - xarray
   - matplotlib
   - cloudpickle

--- a/tests/test_env.yml
+++ b/tests/test_env.yml
@@ -6,7 +6,7 @@ dependencies:
   - numpy
   - sympy
   - scipy
-  - pandas=1.2.5
+  - pandas<1.3
   - xarray
   - matplotlib
   - cloudpickle


### PR DESCRIPTION
minor fixes to make unittests working again 
- avoid version-conflicts with `pandas`, `xarray` and `__future__` imports when unpickling results